### PR TITLE
Modernise compilers image: single Dockerfile, latest stable, cgroup v2 isolate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,33 @@
 
 Base Docker image that ships every language toolchain Judge0 executes
 student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
-upstream artifact) and `newtonschool/judge0-newton-compiler:0.27+` (Newton's
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.28+` (Newton's
 modernised + trimmed artifact, which is what `Newton-School/judge0` actually
 consumes).
+
+## What changed in 0.28 (vs 0.27)
+
+Two-part diff:
+
+1. **Dropped GCC 14.2.0** — only GCC 9.5.0 retained for C/C++. Production
+   submissions never adopted the GCC 14 ids; the second toolchain build
+   was paying ~45 min of compile time and ~1 GB of image for nothing.
+   `GCC_VERSION` env pin and the Tier 1 build are gone; ids 3003/3004 in
+   judge0 (`Newton-School/judge0`) move to `archived.rb` in the same
+   release.
+2. **Re-added Kotlin 2.3.21 and Scala 3.8.3** — both were trimmed in 0.27
+   but are needed again for re-introduced course tracks. Sit in Tier 4
+   alongside the JDK. `kotlinc`/`kotlin`/`scalac`/`scala` symlinked into
+   `/usr/local/bin`; versioned install dirs at `/usr/local/kotlin-2.3.21`
+   and `/usr/local/scala-3.8.3`.
+3. **Pinned nand2tetris-web-ide to a specific commit SHA**
+   (`NAND2TETRIS_REF`). The repo is public and Newton-owned, so any
+   accidental push to its default branch would otherwise change image
+   behavior on the next rebuild. Bumping the pin is now an intentional
+   action, not a side effect.
+
+Plain text (judge0 id 43) needs no toolchain — handled purely on the
+judge0 side.
 
 ## What changed in 0.27 (vs 0.26)
 
@@ -33,9 +57,10 @@ weren't actually using were ~6-7 GB of the image. Dropped toolchains:
 Also: `gfortran` removed from base apt and `--enable-languages=c,c++` (no
 fortran) on both GCC builds, since Fortran (id 59) was archived.
 
-What's still in: GCC 9.5 + 14.2 (C/C++), Java 21, Python 3.13 + 3.12 ML,
-Ruby 3.3.6, Node 22 + TypeScript, Go 1.23, Rust 1.83, R 4.5, Bash 5.2,
-NASM, FreeBASIC, SQLite, MARS, nand2tetris, isolate v2.
+What's still in (after 0.28): GCC 9.5 (C/C++), Java 21, Kotlin 2.3.21,
+Scala 3.8.3, Python 3.13 + 3.12 ML, Ruby 3.3.6, Node 22 + TypeScript,
+Go 1.23, Rust 1.83, R 4.5, Bash 5.2, NASM, FreeBASIC, SQLite, MARS,
+nand2tetris, isolate v2.
 
 ## Repo layout you will care about
 
@@ -61,10 +86,10 @@ NASM, FreeBASIC, SQLite, MARS, nand2tetris, isolate v2.
 - isolate v2 (sandbox) — cgroup v2 capable. The judge0 Rails app currently
   runs it in non-cgroup mode (per-process rlimits) because in-container
   cgroup-v2 delegation needs systemd, which the container doesn't run.
-- One latest-stable per language family, except **GCC 9.5.0 is kept
-  alongside GCC 14.2.0** so legacy student-code compile paths (judge0
-  language ids 48/49/50/52/53/54) keep working with a 9.x ABI/diagnostic
-  surface, while new submissions can target ids 1001/1002 for GCC 14.
+- One latest-stable per language family. **GCC pinned to 9.5.0 only**
+  (modern GCC 14 path dropped in 0.28); ids 48/49/50/52/53/54 still serve
+  the GCC 9.x ABI/diagnostic surface. ids 3003/3004 (GCC 14 C/C++) are
+  archived on the judge0 side.
 - Drops: Python 2.7, Mono, VB.Net.
 - Multi-arch (amd64 + arm64) via `ARG TARGETARCH` branching. arm64 falls
   back to bookworm `apt sbcl` and `apt fpc` (no upstream binaries) and
@@ -72,14 +97,19 @@ NASM, FreeBASIC, SQLite, MARS, nand2tetris, isolate v2.
 
 ### Layer ordering rule
 
-Tier 0 (foundation, frozen) at the top, tier 11 (Python ML pip install,
+Tier 0 (foundation, frozen) at the top, tier 10 (Python ML pip install,
 volatile) at the bottom. Editing the Python ML package list invalidates
 ONE layer; bumping a language version cascades to everything below it.
 **Append new languages at the bottom; don't insert in the middle.**
 
-The version pins are all in the top `ENV` block. Editing any of those
-invalidates every layer — don't bump versions there casually. For purely
-additive package changes, append a new RUN at the bottom.
+**0.28+ change: per-language version pins.** Each language's version
+ENV now sits directly above its install RUN, instead of all pins
+sharing one mega-ENV at the top of the file. Bumping one language only
+invalidates that ENV layer + the RUN below it + everything further
+down. Adding a new language at the bottom invalidates nothing above.
+Pre-0.28, the top mega-ENV meant any single bump rebuilt the whole
+image (45+ min wasted on the JDK_FILE_VERSION incident in 0.26 was the
+proximate cause of this restructure).
 
 ## Build commands
 
@@ -87,13 +117,13 @@ additive package changes, append a new RUN at the bottom.
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.27-arm64 \
+  -t newtonschool/judge0-newton-compiler:0.28-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.27 \
+  -t newtonschool/judge0-newton-compiler:0.28 \
   --load .
 ```
 
@@ -106,13 +136,13 @@ drops.
 ```bash
 docker run --rm \
   -v "$PWD/bin:/work/bin:ro" \
-  newtonschool/judge0-newton-compiler:0.27-arm64 \
+  newtonschool/judge0-newton-compiler:0.28-arm64 \
   bash /work/bin/newton-test
 ```
 
-Expected (post 0.27 trim): 17 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and
-FreeBASIC are amd64-only upstream and skip on arm64). 19 PASS / 0 FAIL /
-0 SKIP on amd64.
+Expected (post 0.28: GCC 14 dropped, Kotlin + Scala added → net +1):
+18 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and FreeBASIC are amd64-only
+upstream and skip on arm64). 20 PASS / 0 FAIL / 0 SKIP on amd64.
 
 If this isn't green, DON'T tag/push.
 
@@ -155,8 +185,9 @@ If this isn't green, DON'T tag/push.
 
 - Docker Hub: `newtonschool/judge0-newton-compiler`
 - Tags currently published: `0.25` (legacy), `0.26` (Phase 2 modernised),
-  `0.27` (Phase 3 trimmed — current target)
-- Phase-3 production tag: `0.27` (amd64) — produced on EC2
+  `0.27` (Phase 3 trimmed), `0.28` (Phase 4 — GCC 14 dropped, Kotlin/Scala
+  re-added; current target)
+- Phase-4 production tag: `0.28` (amd64) — produced on EC2
 
 ## Production deploys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,12 @@ If this isn't green, DON'T tag/push.
 5. **MARS jar URL uses major_minor only.** The release tag is `v.4.5.1`
    but the asset is `Mars4_5.jar` (no trailing `_1`). Don't try to compute
    the filename from the version string.
-6. **Bash mirror at `ftpmirror.gnu.org/bash/` returns 403.** Use
-   `ftp.gnu.org/gnu/bash/` directly.
+6. **`ftpmirror.gnu.org` returns transient 403s from inside buildkit.**
+   Bash hit this in 0.26; GCC 9.5 hit the same in 0.28 (a build that had
+   been working previously failed on rebuild because the auto-redirecting
+   mirror sent buildkit to a rate-limited downstream). Always use
+   `ftp.gnu.org/gnu/<project>/` directly for any GNU source — applies to
+   bash, gcc, gnucobol, octave, etc.
 7. **SBCL has no upstream arm64 Linux binary.** arm64 falls back to
    bookworm `apt sbcl` (2.2.x); amd64 keeps the SourceForge binary
    (2.4.10).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,40 @@
 
 Base Docker image that ships every language toolchain Judge0 executes
 student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
-upstream artifact) and `newtonschool/judge0-newton-compiler:0.26+` (Newton's
-modernised artifact, which is what `Newton-School/judge0` actually consumes).
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.27+` (Newton's
+modernised + trimmed artifact, which is what `Newton-School/judge0` actually
+consumes).
+
+## What changed in 0.27 (vs 0.26)
+
+Aggressive trim driven by prod usage data: the languages that students
+weren't actually using were ~6-7 GB of the image. Dropped toolchains:
+
+- **Clang/LLVM** (C/C++/Obj-C apt path) — Clang ids 75/76/79
+- **.NET 8 SDK + dotnet-script** — C# (51) and F# (87)
+- **Haskell GHC** (~3 GB by itself) — id 61
+- **Swift** — id 83
+- **Erlang/OTP + Elixir** — ids 58, 57
+- **OCaml** — id 65
+- **Octave** — id 66
+- **Free Pascal (FPC)** — id 67
+- **GnuCOBOL** — id 77
+- **GNU Prolog** — id 69
+- **SBCL** (Common Lisp) — id 55
+- **DMD/LDC** (D) — id 56
+- **Lua** — id 64
+- **PHP** — id 68
+- **Kotlin** — id 78
+- **Scala 3** — id 81
+- **Groovy** — id 88
+- **Clojure** — id 86
+
+Also: `gfortran` removed from base apt and `--enable-languages=c,c++` (no
+fortran) on both GCC builds, since Fortran (id 59) was archived.
+
+What's still in: GCC 9.5 + 14.2 (C/C++), Java 21, Python 3.13 + 3.12 ML,
+Ruby 3.3.6, Node 22 + TypeScript, Go 1.23, Rust 1.83, R 4.5, Bash 5.2,
+NASM, FreeBASIC, SQLite, MARS, nand2tetris, isolate v2.
 
 ## Repo layout you will care about
 
@@ -55,13 +87,13 @@ additive package changes, append a new RUN at the bottom.
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.26-arm64 \
+  -t newtonschool/judge0-newton-compiler:0.27-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.26 \
+  -t newtonschool/judge0-newton-compiler:0.27 \
   --load .
 ```
 
@@ -74,12 +106,13 @@ drops.
 ```bash
 docker run --rm \
   -v "$PWD/bin:/work/bin:ro" \
-  newtonschool/judge0-newton-compiler:0.26-arm64 \
+  newtonschool/judge0-newton-compiler:0.27-arm64 \
   bash /work/bin/newton-test
 ```
 
-Expected: 40 PASS, 0 FAIL, 2 SKIP (NASM and FreeBASIC are amd64-only
-upstream and skip on arm64). On amd64 those two activate, so 42 PASS.
+Expected (post 0.27 trim): 17 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and
+FreeBASIC are amd64-only upstream and skip on arm64). 19 PASS / 0 FAIL /
+0 SKIP on amd64.
 
 If this isn't green, DON'T tag/push.
 
@@ -121,8 +154,9 @@ If this isn't green, DON'T tag/push.
 ## Image is published as
 
 - Docker Hub: `newtonschool/judge0-newton-compiler`
-- Tags currently published: `0.25` (legacy production), `0.26-arm64`
-- Phase-2 production tag: `0.26` (amd64) — produced on EC2
+- Tags currently published: `0.25` (legacy), `0.26` (Phase 2 modernised),
+  `0.27` (Phase 3 trimmed — current target)
+- Phase-3 production tag: `0.27` (amd64) — produced on EC2
 
 ## Production deploys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,8 @@ If this isn't green, DON'T tag/push.
 5. **MARS jar URL uses major_minor only.** The release tag is `v.4.5.1`
    but the asset is `Mars4_5.jar` (no trailing `_1`). Don't try to compute
    the filename from the version string.
-6. **`ftpmirror.gnu.org` returns transient 403s from inside buildkit.**
-   Bash hit this in 0.26; GCC 9.5 hit the same in 0.28 (a build that had
-   been working previously failed on rebuild because the auto-redirecting
-   mirror sent buildkit to a rate-limited downstream). Always use
-   `ftp.gnu.org/gnu/<project>/` directly for any GNU source — applies to
-   bash, gcc, gnucobol, octave, etc.
+6. **Bash mirror at `ftpmirror.gnu.org/bash/` returns 403.** Use
+   `ftp.gnu.org/gnu/bash/` directly.
 7. **SBCL has no upstream arm64 Linux binary.** arm64 falls back to
    bookworm `apt sbcl` (2.2.x); amd64 keeps the SourceForge binary
    (2.4.10).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# compilers — Newton School fork
+
+Base Docker image that ships every language toolchain Judge0 executes
+student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.26+` (Newton's
+modernised artifact, which is what `Newton-School/judge0` actually consumes).
+
+## Repo layout you will care about
+
+```
+.
+├── Dockerfile                          # upstream judge0/compilers:1.4.0 layout, frozen
+├── NewtonDockerFiles/
+│   ├── NewtonDockerfile-v1             # 0.25 production: layered on judge0/compilers:1.4.0
+│   └── NewtonDockerfile-v2             # 0.26+ production: standalone on bookworm — USE THIS
+├── bin/
+│   ├── newton-test                     # 40+ language smoke test (must pass before tagging)
+│   ├── run-tests / debug-tests         # upstream tests, mostly unused
+├── extra/                              # upstream "extra" flavour, ignored
+├── slim/                               # upstream "slim" flavour, ignored
+└── tests/<lang>/                       # upstream per-language tests; we don't run these
+```
+
+## What's in NewtonDockerfile-v2
+
+- Base: `buildpack-deps:bookworm` (Debian 12). The pre-0.26 image was on
+  `judge0/buildpack-deps:buster-2019-12-28` and required a sources.list
+  rewrite to `archive.debian.org` to do anything.
+- isolate v2 (sandbox) — cgroup v2 capable. The judge0 Rails app currently
+  runs it in non-cgroup mode (per-process rlimits) because in-container
+  cgroup-v2 delegation needs systemd, which the container doesn't run.
+- One latest-stable per language family, except **GCC 9.5.0 is kept
+  alongside GCC 14.2.0** so legacy student-code compile paths (judge0
+  language ids 48/49/50/52/53/54) keep working with a 9.x ABI/diagnostic
+  surface, while new submissions can target ids 1001/1002 for GCC 14.
+- Drops: Python 2.7, Mono, VB.Net.
+- Multi-arch (amd64 + arm64) via `ARG TARGETARCH` branching. arm64 falls
+  back to bookworm `apt sbcl` and `apt fpc` (no upstream binaries) and
+  uses LDC instead of DMD.
+
+### Layer ordering rule
+
+Tier 0 (foundation, frozen) at the top, tier 11 (Python ML pip install,
+volatile) at the bottom. Editing the Python ML package list invalidates
+ONE layer; bumping a language version cascades to everything below it.
+**Append new languages at the bottom; don't insert in the middle.**
+
+The version pins are all in the top `ENV` block. Editing any of those
+invalidates every layer — don't bump versions there casually. For purely
+additive package changes, append a new RUN at the bottom.
+
+## Build commands
+
+```bash
+# arm64 native (Mac dev) — ~2-2.5 hrs from scratch
+docker buildx build --platform linux/arm64 \
+  -f NewtonDockerFiles/NewtonDockerfile-v2 \
+  -t newtonschool/judge0-newton-compiler:0.26-arm64 \
+  --load .
+
+# amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
+docker buildx build --platform linux/amd64 \
+  -f NewtonDockerFiles/NewtonDockerfile-v2 \
+  -t newtonschool/judge0-newton-compiler:0.26 \
+  --load .
+```
+
+Disk: needs ≥100 GB host volume; buildkit cache balloons to 30-50 GB
+during a fresh build. **Run inside `tmux`/`screen`** on EC2 to survive SSH
+drops.
+
+## Smoke test
+
+```bash
+docker run --rm \
+  -v "$PWD/bin:/work/bin:ro" \
+  newtonschool/judge0-newton-compiler:0.26-arm64 \
+  bash /work/bin/newton-test
+```
+
+Expected: 40 PASS, 0 FAIL, 2 SKIP (NASM and FreeBASIC are amd64-only
+upstream and skip on arm64). On amd64 those two activate, so 42 PASS.
+
+If this isn't green, DON'T tag/push.
+
+## Common pitfalls (encountered while building 0.26 — don't repeat)
+
+1. **`/bin/sh` is dash, not bash.** RUN steps use POSIX shell. Bash-only
+   constructs like `${var//pat/repl}` fail with `Bad substitution`. Use
+   `tr` or compute the variant ahead of time as a separate `ENV` line.
+2. **`cd <dir> && rm -rf <dir> && next-cmd` removes the cwd**, then the
+   next command's open-cwd lookup fails ("rb_sysopen", "getcwd() failed").
+   Always `cd /` (or `cd ..`) before `rm -rf`. Affects pip, Rscript,
+   anything that opens cwd at startup.
+3. **GCC 9.5.0, not 9.2.0.** GCC 9.2 was the upstream version but doesn't
+   build cleanly against bookworm's modern glibc. 9.5.0 is the last 9.x
+   patch and builds fine. Add `--disable-libsanitizer` to the configure
+   for the same reason.
+4. **GHC arm64 has no deb12 build.** Use `aarch64-deb11-linux` for arm64,
+   `x86_64-deb12-linux` for amd64. The deb11 binary needs a libtinfo5
+   shim because bookworm only ships libtinfo6.
+5. **MARS jar URL uses major_minor only.** The release tag is `v.4.5.1`
+   but the asset is `Mars4_5.jar` (no trailing `_1`). Don't try to compute
+   the filename from the version string.
+6. **Bash mirror at `ftpmirror.gnu.org/bash/` returns 403.** Use
+   `ftp.gnu.org/gnu/bash/` directly.
+7. **SBCL has no upstream arm64 Linux binary.** arm64 falls back to
+   bookworm `apt sbcl` (2.2.x); amd64 keeps the SourceForge binary
+   (2.4.10).
+8. **DMD has no arm64 Linux binary.** arm64 uses LDC; amd64 uses DMD. The
+   arm64 case adds a `linux/bin64/dmd` symlink so consumers can use a
+   single path.
+9. **nand2tetris-web-ide pins `node: "20.9.0"` exactly** in package.json.
+   We're on Node 22 in 0.26+. Use `npm install --force` to bypass the
+   engine pin.
+10. **Adding to the top ENV block invalidates EVERYTHING below.** During
+    initial 0.26 work, adding `JDK_FILE_VERSION` near the JDK pin caused
+    a fresh GCC 14 rebuild (45+ min lost). For values needed only by one
+    RUN, compute them inline in that RUN.
+
+## Image is published as
+
+- Docker Hub: `newtonschool/judge0-newton-compiler`
+- Tags currently published: `0.25` (legacy production), `0.26-arm64`
+- Phase-2 production tag: `0.26` (amd64) — produced on EC2
+
+## Production deploys
+
+The compilers image is the **base image only** — judge0 builds on top.
+Don't deploy this image directly anywhere; deploy `newtonschool/newton-judge0:<tag>`
+from `Newton-School/judge0` instead.
+
+## Working notes
+
+- `docker-compose.dev.yml` doesn't live here; it lives in
+  `Newton-School/judge0`. This repo is build-only.
+- The upstream `judge0/compilers` repo is the original source; rebasing on
+  it is generally NOT desired any more (Newton has diverged with the
+  v2 single-Dockerfile rewrite). For curiosity, see
+  https://github.com/judge0/compilers.

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -252,10 +252,16 @@ RUN set -xe && \
     make -j"$(nproc)" && make install && \
     cd / && rm -rf /tmp/sqlite /tmp/sqlite.tar.gz
 
-# FreeBASIC (amd64 prebuilt; arm64 not officially supported - skipped)
+# FreeBASIC (amd64 prebuilt; arm64 not officially supported - skipped).
+# As of FreeBASIC 1.10.x, SourceForge moved the Linux binaries into a
+# per-version subdirectory (FreeBASIC-${VERSION}/Binaries-Linux/) rather
+# than the older flat /Binaries%20-%20Linux/ layout — and the directory
+# name is plain "Binaries-Linux" without spaces. Older Newton Dockerfile
+# revisions used the flat URL with FBC 1.07.1 and worked; for 1.10.1 we
+# need this updated path.
 RUN set -xe && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
-        curl -fSsL "https://downloads.sourceforge.net/project/fbc/Binaries%20-%20Linux/FreeBASIC-${FBC_VERSION}-linux-x86_64.tar.gz" -o /tmp/fbc.tar.gz && \
+        curl -fSsL "https://downloads.sourceforge.net/project/fbc/FreeBASIC-${FBC_VERSION}/Binaries-Linux/FreeBASIC-${FBC_VERSION}-linux-x86_64.tar.gz" -o /tmp/fbc.tar.gz && \
         mkdir -p /usr/local/fbc-${FBC_VERSION} && \
         tar -xf /tmp/fbc.tar.gz -C /usr/local/fbc-${FBC_VERSION} --strip-components=1 && \
         rm /tmp/fbc.tar.gz ; \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -118,6 +118,7 @@ RUN set -xe && \
         libsystemd-dev \
         libfontconfig1 \
         libgl1 \
+        gfortran \
         pkg-config \
         autoconf \
         automake \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -1,0 +1,677 @@
+# syntax=docker/dockerfile:1.6
+#
+# Newton School Judge0 compilers image - v2 (modernised, single-layer)
+#
+# - Single Dockerfile (no longer layered on judge0/compilers:1.4.0).
+# - Base: buildpack-deps:bookworm (Debian 12).
+# - One latest-stable per language family, except GCC where 9.5.0 is kept
+#   alongside 14.2.0 to preserve the GCC 9.x compile path for legacy
+#   student submissions.
+# - cgroup v2 only via isolate v2.
+# - Drops: Python 2.7, Mono, VB.Net.
+# - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
+#
+# Layer ordering: stable-on-top, volatile-on-bottom.
+#   Tier 0: foundation (base/apt/isolate)
+#   Tier 1: GCC, Clang
+#   Tier 2: utility/niche langs (rare bumps)
+#   Tier 3: yearly langs (Haskell, OCaml, Erlang, Elixir, R)
+#   Tier 4: JVM stack (JDK, Kotlin, Scala, Groovy, Clojure)
+#   Tier 5: .NET LTS
+#   Tier 6: yearly mainstream compiled (Swift, Go, Rust)
+#   Tier 7: yearly mainstream scripting (PHP, Ruby, Python default)
+#   Tier 8: Node + TypeScript (TypeScript split out, frequent bumps)
+#   Tier 9: Python 3.12 ML interpreter (split from packages)
+#   Tier 10: Newton extras (MARS, nand2tetris)
+#   Tier 11: Python ML pip install — most volatile, BOTTOM
+#
+# Cache-friendly editing rules:
+#   - Adding/removing pip pkgs: edit the bottom layer only.
+#   - Bumping a language: cascades to everything below it. Choose pins thoughtfully.
+#   - Adding a new language: APPEND a new RUN at the bottom (above pip install)
+#     so existing cache stays warm.
+#
+# Multi-arch: amd64 + arm64 supported via TARGETARCH branching.
+# Build:
+#   docker buildx build --platform linux/arm64 \
+#     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
+#     -t newtonschool/judge0-newton-compiler:0.26-arm64 \
+#     compilers
+#
+FROM buildpack-deps:bookworm AS base
+
+ARG TARGETARCH
+
+# ────────────────────────────────────────────────────────────────────────
+# Version pins.  WARNING: this ENV layer sits at the top — *any* edit here
+# invalidates the cache for every layer below.  For simple package adds,
+# prefer appending a new RUN at the bottom.
+# ────────────────────────────────────────────────────────────────────────
+ENV GCC_LEGACY_VERSION=9.5.0 \
+    GCC_VERSION=14.2.0 \
+    LLVM_VERSION=19 \
+    PYTHON_VERSION=3.13.1 \
+    PYTHON_ML_VERSION=3.12.7 \
+    RUBY_VERSION=3.3.6 \
+    NODE_VERSION=22.11.0 \
+    TYPESCRIPT_VERSION=5.7.2 \
+    JDK_VERSION=21.0.5+11 \
+    KOTLIN_VERSION=2.1.0 \
+    SCALA_VERSION=3.6.2 \
+    GROOVY_VERSION=4.0.24 \
+    CLOJURE_VERSION=1.12.0.1495 \
+    GO_VERSION=1.23.4 \
+    RUST_VERSION=1.83.0 \
+    PHP_VERSION=8.4.1 \
+    SWIFT_VERSION=6.0.3 \
+    GHC_VERSION=9.10.1 \
+    OCAML_VERSION=5.2.0 \
+    OTP_VERSION=27.1.2 \
+    ELIXIR_VERSION=1.17.3 \
+    R_VERSION=4.5.2 \
+    LUA_VERSION=5.4.7 \
+    FPC_VERSION=3.2.2 \
+    SBCL_VERSION=2.4.10 \
+    DMD_VERSION=2.110.0 \
+    LDC_VERSION=1.39.0 \
+    GNUCOBOL_VERSION=3.2 \
+    GPROLOG_VERSION=1.5.0 \
+    BASH_VERSION=5.2.37 \
+    FBC_VERSION=1.10.1 \
+    NASM_VERSION=2.16.03 \
+    SQLITE_VERSION=3470000 \
+    SQLITE_YEAR=2024 \
+    DOTNET_VERSION=8.0.404 \
+    ISOLATE_REF=v2.0 \
+    NAND2TETRIS_REPO=https://github.com/Newton-School/nand2tetris-web-ide.git \
+    MARS_VERSION=4.5.1
+
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    DEBIAN_FRONTEND=noninteractive
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 0 — foundation (almost never changes)
+# ════════════════════════════════════════════════════════════════════════
+
+# Base apt deps
+RUN set -xe && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        cmake \
+        gnupg \
+        dirmngr \
+        sudo \
+        unzip \
+        zip \
+        xz-utils \
+        bzip2 \
+        locales \
+        git \
+        bison \
+        flex \
+        re2c \
+        libgmp-dev \
+        libncurses-dev \
+        libreadline-dev \
+        libssl-dev \
+        libffi-dev \
+        zlib1g-dev \
+        liblzma-dev \
+        libbz2-dev \
+        libsqlite3-dev \
+        libpcre2-dev \
+        libcurl4-openssl-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libyaml-dev \
+        libgdbm-dev \
+        libdb-dev \
+        libblas-dev \
+        liblapack-dev \
+        libcap-dev \
+        libsystemd-dev \
+        libfontconfig1 \
+        libgl1 \
+        gfortran \
+        pkg-config \
+        autoconf \
+        automake \
+        libtool \
+        m4 && \
+    echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen && \
+    rm -rf /var/lib/apt/lists/*
+
+# isolate v2 (cgroup v2 sandbox)
+RUN set -xe && \
+    git clone https://github.com/ioi/isolate.git /tmp/isolate && \
+    cd /tmp/isolate && \
+    git checkout ${ISOLATE_REF} && \
+    make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/isolate
+ENV BOX_ROOT=/var/local/lib/isolate
+
+# GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
+RUN set -xe && \
+    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
+    mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
+    rm /tmp/gcc.tar.gz && \
+    cd /tmp/gcc && \
+    ./contrib/download_prerequisites && \
+    rm -f *.tar.* && \
+    mkdir /tmp/gcc-build && cd /tmp/gcc-build && \
+    /tmp/gcc/configure \
+        --disable-multilib \
+        --disable-libsanitizer \
+        --enable-languages=c,c++,fortran \
+        --prefix=/usr/local/gcc-${GCC_LEGACY_VERSION} && \
+    make -j"$(nproc)" && \
+    make -j"$(nproc)" install-strip && \
+    cd / && rm -rf /tmp/gcc /tmp/gcc-build
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 1 — modern C/C++ toolchains (yearly bumps)
+# ════════════════════════════════════════════════════════════════════════
+
+# GCC 14.2.0 — current default for new submissions
+RUN set -xe && \
+    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
+    mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
+    rm /tmp/gcc.tar.gz && \
+    cd /tmp/gcc && \
+    ./contrib/download_prerequisites && \
+    rm -f *.tar.* && \
+    mkdir /tmp/gcc-build && cd /tmp/gcc-build && \
+    /tmp/gcc/configure \
+        --disable-multilib \
+        --enable-languages=c,c++,fortran \
+        --prefix=/usr/local/gcc-${GCC_VERSION} && \
+    make -j"$(nproc)" && \
+    make -j"$(nproc)" install-strip && \
+    cd / && rm -rf /tmp/gcc /tmp/gcc-build
+
+# LLVM/Clang ${LLVM_VERSION} from apt.llvm.org (C, C++, Objective-C)
+RUN set -xe && \
+    curl -fsSL "https://apt.llvm.org/llvm-snapshot.gpg.key" | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg && \
+    echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        clang-${LLVM_VERSION} \
+        lld-${LLVM_VERSION} \
+        libc++-${LLVM_VERSION}-dev \
+        libc++abi-${LLVM_VERSION}-dev \
+        gnustep-devel && \
+    ln -sf /usr/bin/clang-${LLVM_VERSION} /usr/local/bin/clang && \
+    ln -sf /usr/bin/clang++-${LLVM_VERSION} /usr/local/bin/clang++ && \
+    rm -rf /var/lib/apt/lists/*
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 2 — utility / niche languages (very rare bumps)
+# ════════════════════════════════════════════════════════════════════════
+
+# Bash
+RUN set -xe && \
+    curl -fSsL "https://ftp.gnu.org/gnu/bash/bash-${BASH_VERSION}.tar.gz" -o /tmp/bash.tar.gz && \
+    mkdir /tmp/bash && tar -xf /tmp/bash.tar.gz -C /tmp/bash --strip-components=1 && \
+    cd /tmp/bash && \
+    ./configure --prefix=/usr/local/bash-${BASH_VERSION} && \
+    make -j"$(nproc)" && make install && \
+    cd / && rm -rf /tmp/bash /tmp/bash.tar.gz
+
+# Lua
+RUN set -xe && \
+    curl -fSsL "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" -o /tmp/lua.tar.gz && \
+    mkdir /tmp/lua && tar -xf /tmp/lua.tar.gz -C /tmp/lua --strip-components=1 && \
+    cd /tmp/lua && \
+    make linux -j"$(nproc)" && \
+    make install INSTALL_TOP=/usr/local/lua-${LUA_VERSION} && \
+    cd / && rm -rf /tmp/lua /tmp/lua.tar.gz
+
+# NASM (assembler — amd64 only at runtime, but builds on both arches)
+RUN set -xe && \
+    curl -fSsL "https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz" -o /tmp/nasm.tar.gz && \
+    mkdir /tmp/nasm && tar -xf /tmp/nasm.tar.gz -C /tmp/nasm --strip-components=1 && \
+    cd /tmp/nasm && \
+    ./configure --prefix=/usr/local/nasm-${NASM_VERSION} && \
+    make -j"$(nproc)" nasm ndisasm && \
+    make install && \
+    echo '#!/bin/sh' > /usr/local/nasm-${NASM_VERSION}/bin/nasmld && \
+    echo 'set -e' >> /usr/local/nasm-${NASM_VERSION}/bin/nasmld && \
+    echo "/usr/local/nasm-${NASM_VERSION}/bin/nasm -o main.o \"\$@\" && ld main.o" >> /usr/local/nasm-${NASM_VERSION}/bin/nasmld && \
+    chmod +x /usr/local/nasm-${NASM_VERSION}/bin/nasmld && \
+    cd / && rm -rf /tmp/nasm /tmp/nasm.tar.gz
+
+# SQLite
+RUN set -xe && \
+    curl -fSsL "https://www.sqlite.org/${SQLITE_YEAR}/sqlite-autoconf-${SQLITE_VERSION}.tar.gz" -o /tmp/sqlite.tar.gz && \
+    mkdir /tmp/sqlite && tar -xf /tmp/sqlite.tar.gz -C /tmp/sqlite --strip-components=1 && \
+    cd /tmp/sqlite && \
+    ./configure --prefix=/usr/local/sqlite-autoconf-${SQLITE_VERSION} && \
+    make -j"$(nproc)" && make install && \
+    cd / && rm -rf /tmp/sqlite /tmp/sqlite.tar.gz
+
+# FreeBASIC (amd64 prebuilt; arm64 not officially supported - skipped)
+RUN set -xe && \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -fSsL "https://downloads.sourceforge.net/project/fbc/Binaries%20-%20Linux/FreeBASIC-${FBC_VERSION}-linux-x86_64.tar.gz" -o /tmp/fbc.tar.gz && \
+        mkdir -p /usr/local/fbc-${FBC_VERSION} && \
+        tar -xf /tmp/fbc.tar.gz -C /usr/local/fbc-${FBC_VERSION} --strip-components=1 && \
+        rm /tmp/fbc.tar.gz ; \
+    else \
+        echo "FreeBASIC not available for ${TARGETARCH}; skipping" ; \
+    fi
+
+# Free Pascal: amd64 prebuilt; arm64 falls back to bookworm apt
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) \
+            curl -fSsL "https://downloads.sourceforge.net/project/freepascal/Linux/${FPC_VERSION}/fpc-${FPC_VERSION}.x86_64-linux.tar" -o /tmp/fpc.tar && \
+            mkdir /tmp/fpc && tar -xf /tmp/fpc.tar -C /tmp/fpc --strip-components=1 && \
+            cd /tmp/fpc && \
+            echo "/usr/local/fpc-${FPC_VERSION}" | sh install.sh && \
+            cd / && rm -rf /tmp/fpc /tmp/fpc.tar \
+            ;; \
+        arm64) \
+            apt-get update && \
+            apt-get install -y --no-install-recommends fpc && \
+            rm -rf /var/lib/apt/lists/* && \
+            FPC_APT_VER="$(dpkg-query -W -f='${Version}' fpc | cut -d- -f1 | cut -d+ -f1)" && \
+            mkdir -p /usr/local/fpc-${FPC_APT_VER}/bin && \
+            ln -sf /usr/bin/fpc /usr/local/fpc-${FPC_APT_VER}/bin/fpc \
+            ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac
+
+# GnuCOBOL
+RUN set -xe && \
+    curl -fSsL "https://ftp.gnu.org/gnu/gnucobol/gnucobol-${GNUCOBOL_VERSION}.tar.xz" -o /tmp/cobol.tar.xz && \
+    mkdir /tmp/cobol && tar -xf /tmp/cobol.tar.xz -C /tmp/cobol --strip-components=1 && \
+    cd /tmp/cobol && \
+    ./configure --prefix=/usr/local/gnucobol-${GNUCOBOL_VERSION} && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/cobol /tmp/cobol.tar.xz
+
+# GNU Prolog
+RUN set -xe && \
+    curl -fSsL "http://gprolog.org/gprolog-${GPROLOG_VERSION}.tar.gz" -o /tmp/gprolog.tar.gz && \
+    mkdir /tmp/gprolog && tar -xf /tmp/gprolog.tar.gz -C /tmp/gprolog --strip-components=1 && \
+    cd /tmp/gprolog/src && \
+    ./configure --prefix=/usr/local/gprolog-${GPROLOG_VERSION} && \
+    make -j"$(nproc)" && make install-strip && \
+    cd / && rm -rf /tmp/gprolog /tmp/gprolog.tar.gz
+
+# SBCL: amd64 prebuilt; arm64 falls back to bookworm apt sbcl
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) \
+            curl -fSsL "https://downloads.sourceforge.net/project/sbcl/sbcl/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2" -o /tmp/sbcl.tar.bz2 && \
+            mkdir /tmp/sbcl && tar -xf /tmp/sbcl.tar.bz2 -C /tmp/sbcl --strip-components=1 && \
+            cd /tmp/sbcl && \
+            INSTALL_ROOT=/usr/local/sbcl-${SBCL_VERSION} sh install.sh && \
+            cd / && rm -rf /tmp/sbcl /tmp/sbcl.tar.bz2 \
+            ;; \
+        arm64) \
+            apt-get update && \
+            apt-get install -y --no-install-recommends sbcl && \
+            rm -rf /var/lib/apt/lists/* && \
+            SBCL_APT_VER="$(dpkg-query -W -f='${Version}' sbcl | cut -d- -f1)" && \
+            mkdir -p /usr/local/sbcl-${SBCL_APT_VER}/bin /usr/local/sbcl-${SBCL_APT_VER}/lib && \
+            ln -sf /usr/bin/sbcl /usr/local/sbcl-${SBCL_APT_VER}/bin/sbcl && \
+            ln -sf /usr/lib/sbcl /usr/local/sbcl-${SBCL_APT_VER}/lib/sbcl && \
+            ln -sf /usr/local/sbcl-${SBCL_APT_VER} /usr/local/sbcl \
+            ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac
+
+# D: DMD on amd64, LDC on arm64 (DMD has no arm64 Linux binary)
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) \
+            curl -fSsL "https://downloads.dlang.org/releases/2.x/${DMD_VERSION}/dmd.${DMD_VERSION}.linux.tar.xz" -o /tmp/d.tar.xz && \
+            mkdir -p /usr/local/d-${DMD_VERSION} && \
+            tar -xf /tmp/d.tar.xz -C /usr/local/d-${DMD_VERSION} --strip-components=1 && \
+            rm -rf /usr/local/d-${DMD_VERSION}/linux/*32 && \
+            rm /tmp/d.tar.xz \
+            ;; \
+        arm64) \
+            curl -fSsL "https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-linux-aarch64.tar.xz" -o /tmp/ldc.tar.xz && \
+            mkdir -p /usr/local/d-${LDC_VERSION} && \
+            tar -xf /tmp/ldc.tar.xz -C /usr/local/d-${LDC_VERSION} --strip-components=1 && \
+            rm /tmp/ldc.tar.xz && \
+            mkdir -p /usr/local/d-${LDC_VERSION}/linux/bin64 && \
+            ln -sf /usr/local/d-${LDC_VERSION}/bin/ldc2 /usr/local/d-${LDC_VERSION}/linux/bin64/dmd \
+            ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac
+
+# Octave (apt — bookworm 8.4 ≈ latest 9.x; saves ~30 min vs source build)
+RUN set -xe && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends octave && \
+    rm -rf /var/lib/apt/lists/* && \
+    OCT_PKG_VER="$(dpkg-query -W -f='${Version}' octave | cut -d- -f1)" && \
+    mkdir -p /usr/local/octave-${OCT_PKG_VER}/bin && \
+    ln -sf /usr/bin/octave-cli /usr/local/octave-${OCT_PKG_VER}/bin/octave-cli && \
+    ln -sf /usr/local/octave-${OCT_PKG_VER} /usr/local/octave
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 3 — yearly-cadence languages (Haskell, OCaml, Erlang, Elixir, R)
+# ════════════════════════════════════════════════════════════════════════
+
+# Haskell GHC (prebuilt). arm64 has no deb12 build → use deb11 + libtinfo5 shim
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) GHC_ARCH=x86_64-deb12-linux ;; \
+        arm64) GHC_ARCH=aarch64-deb11-linux ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    if [ ! -e /usr/lib/aarch64-linux-gnu/libtinfo.so.5 ] && [ -e /usr/lib/aarch64-linux-gnu/libtinfo.so.6 ]; then \
+        ln -sf /usr/lib/aarch64-linux-gnu/libtinfo.so.6 /usr/lib/aarch64-linux-gnu/libtinfo.so.5; \
+    fi && \
+    if [ ! -e /usr/lib/x86_64-linux-gnu/libtinfo.so.5 ] && [ -e /usr/lib/x86_64-linux-gnu/libtinfo.so.6 ]; then \
+        ln -sf /usr/lib/x86_64-linux-gnu/libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5; \
+    fi && \
+    curl -fSsL "https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-${GHC_ARCH}.tar.xz" -o /tmp/ghc.tar.xz && \
+    mkdir /tmp/ghc && tar -xf /tmp/ghc.tar.xz -C /tmp/ghc --strip-components=1 && \
+    cd /tmp/ghc && \
+    ./configure --prefix=/usr/local/ghc-${GHC_VERSION} && \
+    make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/ghc /tmp/ghc.tar.xz
+
+# OCaml (source)
+RUN set -xe && \
+    curl -fSsL "https://github.com/ocaml/ocaml/archive/refs/tags/${OCAML_VERSION}.tar.gz" -o /tmp/ocaml.tar.gz && \
+    mkdir /tmp/ocaml && tar -xf /tmp/ocaml.tar.gz -C /tmp/ocaml --strip-components=1 && \
+    cd /tmp/ocaml && \
+    ./configure --prefix=/usr/local/ocaml-${OCAML_VERSION} \
+                --disable-ocamldoc --disable-debugger && \
+    make -j"$(nproc)" && make install && \
+    cd / && rm -rf /tmp/ocaml /tmp/ocaml.tar.gz
+
+# Erlang/OTP (source build — slowest layer in this tier, ~15-20 min)
+RUN set -xe && \
+    curl -fSsL "https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" -o /tmp/otp.tar.gz && \
+    mkdir /tmp/otp && tar -xf /tmp/otp.tar.gz -C /tmp/otp --strip-components=1 && \
+    cd /tmp/otp && \
+    ./configure --prefix=/usr/local/erlang-${OTP_VERSION} \
+                --without-javac --without-wx --without-debugger \
+                --without-observer --without-et && \
+    make -j"$(nproc)" && make install && \
+    cd / && rm -rf /tmp/otp /tmp/otp.tar.gz && \
+    ln -sf /usr/local/erlang-${OTP_VERSION}/bin/erl /usr/local/bin/erl
+
+# Elixir (prebuilt for the OTP we just built)
+RUN set -xe && \
+    curl -fSsL "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/elixir-otp-${OTP_VERSION%%.*}.zip" -o /tmp/elixir.zip && \
+    mkdir -p /usr/local/elixir-${ELIXIR_VERSION} && \
+    unzip -q /tmp/elixir.zip -d /usr/local/elixir-${ELIXIR_VERSION} && \
+    rm /tmp/elixir.zip
+
+# R (source build + data.table preinstall)
+RUN set -xe && \
+    curl -fSsL "https://cloud.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz" -o /tmp/r.tar.gz && \
+    mkdir /tmp/r && tar -xf /tmp/r.tar.gz -C /tmp/r --strip-components=1 && \
+    cd /tmp/r && \
+    ./configure --prefix=/usr/local/r-${R_VERSION} --with-x=no --enable-R-shlib && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/r /tmp/r.tar.gz && \
+    /usr/local/r-${R_VERSION}/bin/Rscript -e 'options(repos="https://cloud.r-project.org"); install.packages("data.table")'
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 4 — JVM stack
+# ════════════════════════════════════════════════════════════════════════
+
+# OpenJDK 21 LTS (Eclipse Temurin prebuilt)
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) JDK_ARCH=x64 ;; \
+        arm64) JDK_ARCH=aarch64 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    JDK_FILE_VERSION="$(echo "${JDK_VERSION}" | tr '+' '_')" && \
+    curl -fSsL "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK21U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_FILE_VERSION}.tar.gz" -o /tmp/jdk.tar.gz && \
+    mkdir -p /usr/local/openjdk-21 && \
+    tar -xf /tmp/jdk.tar.gz -C /usr/local/openjdk-21 --strip-components=1 && \
+    rm /tmp/jdk.tar.gz && \
+    ln -sf /usr/local/openjdk-21/bin/java /usr/local/bin/java && \
+    ln -sf /usr/local/openjdk-21/bin/javac /usr/local/bin/javac && \
+    ln -sf /usr/local/openjdk-21/bin/jar /usr/local/bin/jar
+ENV JAVA_HOME=/usr/local/openjdk-21
+
+# Kotlin (JVM, arch-independent zip)
+RUN set -xe && \
+    curl -fSsL "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" -o /tmp/kotlin.zip && \
+    unzip -q /tmp/kotlin.zip -d /usr/local/kotlin-${KOTLIN_VERSION} && \
+    mv /usr/local/kotlin-${KOTLIN_VERSION}/kotlinc/* /usr/local/kotlin-${KOTLIN_VERSION}/ && \
+    rmdir /usr/local/kotlin-${KOTLIN_VERSION}/kotlinc && \
+    rm /tmp/kotlin.zip
+
+# Scala 3 (JVM, arch-independent)
+RUN set -xe && \
+    curl -fSsL "https://github.com/scala/scala3/releases/download/${SCALA_VERSION}/scala3-${SCALA_VERSION}.tar.gz" -o /tmp/scala.tar.gz && \
+    mkdir -p /usr/local/scala-${SCALA_VERSION} && \
+    tar -xf /tmp/scala.tar.gz -C /usr/local/scala-${SCALA_VERSION} --strip-components=1 && \
+    rm /tmp/scala.tar.gz
+
+# Groovy (JVM)
+RUN set -xe && \
+    curl -fSsL "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" -o /tmp/groovy.zip && \
+    unzip -q /tmp/groovy.zip -d /usr/local && \
+    rm /tmp/groovy.zip
+
+# Clojure (JVM, jar via official tools tarball)
+RUN set -xe && \
+    mkdir -p /usr/local/clojure-${CLOJURE_VERSION} && \
+    curl -fSsL "https://github.com/clojure/brew-install/releases/download/${CLOJURE_VERSION}/clojure-tools-${CLOJURE_VERSION}.tar.gz" -o /tmp/clojure.tar.gz && \
+    tar -xf /tmp/clojure.tar.gz -C /tmp && \
+    cp /tmp/clojure-tools/clojure-tools-${CLOJURE_VERSION}.jar /usr/local/clojure-${CLOJURE_VERSION}/clojure.jar && \
+    rm -rf /tmp/clojure-tools /tmp/clojure.tar.gz
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 5 — .NET (LTS, ~2-year cadence)
+# ════════════════════════════════════════════════════════════════════════
+
+# .NET 8 SDK (C#, F#) via Microsoft's official install script
+RUN set -xe && \
+    curl -fSsL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
+    bash /tmp/dotnet-install.sh --version ${DOTNET_VERSION} --install-dir /usr/local/dotnet-sdk && \
+    rm /tmp/dotnet-install.sh && \
+    ln -sf /usr/local/dotnet-sdk/dotnet /usr/local/bin/dotnet
+ENV DOTNET_ROOT=/usr/local/dotnet-sdk \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 6 — yearly mainstream compiled (Swift, Go, Rust)
+# ════════════════════════════════════════════════════════════════════════
+
+# Swift
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) SWIFT_PLATFORM=ubuntu2204 ; SWIFT_ARCH= ;; \
+        arm64) SWIFT_PLATFORM=ubuntu2204-aarch64 ; SWIFT_ARCH=-aarch64 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends libpython3-dev libxml2 && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -fSsL "https://download.swift.org/swift-${SWIFT_VERSION}-release/${SWIFT_PLATFORM}/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04${SWIFT_ARCH}.tar.gz" -o /tmp/swift.tar.gz && \
+    mkdir -p /usr/local/swift-${SWIFT_VERSION} && \
+    tar -xf /tmp/swift.tar.gz -C /usr/local/swift-${SWIFT_VERSION} --strip-components=2 && \
+    rm /tmp/swift.tar.gz
+
+# Go (prebuilt)
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) GO_ARCH=amd64 ;; \
+        arm64) GO_ARCH=arm64 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fSsL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz && \
+    mkdir -p /usr/local/go-${GO_VERSION} && \
+    tar -xf /tmp/go.tar.gz -C /usr/local/go-${GO_VERSION} --strip-components=1 && \
+    rm /tmp/go.tar.gz
+
+# Rust (prebuilt static toolchain)
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) RUST_ARCH=x86_64-unknown-linux-gnu ;; \
+        arm64) RUST_ARCH=aarch64-unknown-linux-gnu ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fSsL "https://static.rust-lang.org/dist/rust-${RUST_VERSION}-${RUST_ARCH}.tar.gz" -o /tmp/rust.tar.gz && \
+    mkdir /tmp/rust && tar -xf /tmp/rust.tar.gz -C /tmp/rust --strip-components=1 && \
+    cd /tmp/rust && \
+    ./install.sh --prefix=/usr/local/rust-${RUST_VERSION} \
+                 --components=rustc,rust-std-${RUST_ARCH},cargo && \
+    cd / && rm -rf /tmp/rust /tmp/rust.tar.gz
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 7 — yearly mainstream scripting (PHP, Ruby, Python default)
+# ════════════════════════════════════════════════════════════════════════
+
+# PHP (build deps installed inline so they don't pollute earlier layers)
+RUN set -xe && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libonig-dev libzip-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -fSsL "https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" -o /tmp/php.tar.xz && \
+    mkdir /tmp/php && tar -xf /tmp/php.tar.xz -C /tmp/php --strip-components=1 && \
+    cd /tmp/php && \
+    ./configure --prefix=/usr/local/php-${PHP_VERSION} \
+                --with-openssl --with-curl --with-zlib \
+                --enable-mbstring --with-zip && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/php /tmp/php.tar.xz
+
+# Ruby
+RUN set -xe && \
+    curl -fSsL "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz" -o /tmp/ruby.tar.gz && \
+    mkdir /tmp/ruby && tar -xf /tmp/ruby.tar.gz -C /tmp/ruby --strip-components=1 && \
+    cd /tmp/ruby && \
+    ./configure \
+        --disable-install-doc \
+        --prefix=/usr/local/ruby-${RUBY_VERSION} && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/ruby /tmp/ruby.tar.gz
+
+# Python 3.13 (default Python; PGO build)
+RUN set -xe && \
+    curl -fSsL "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz" -o /tmp/py.tar.xz && \
+    mkdir /tmp/py && tar -xf /tmp/py.tar.xz -C /tmp/py --strip-components=1 && \
+    cd /tmp/py && \
+    ./configure \
+        --prefix=/usr/local/python-${PYTHON_VERSION} \
+        --enable-optimizations \
+        --with-ensurepip=install && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/py /tmp/py.tar.xz
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 8 — Node + TypeScript (TypeScript split out to isolate npm bumps)
+# ════════════════════════════════════════════════════════════════════════
+
+# Node.js (prebuilt tarball, interpreter only)
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) NODE_ARCH=linux-x64 ;; \
+        arm64) NODE_ARCH=linux-arm64 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fSsL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \
+    mkdir -p /usr/local/node-${NODE_VERSION} && \
+    tar -xf /tmp/node.tar.xz -C /usr/local/node-${NODE_VERSION} --strip-components=1 && \
+    rm /tmp/node.tar.xz && \
+    ln -sf /usr/local/node-${NODE_VERSION}/bin/node /usr/local/bin/node && \
+    ln -sf /usr/local/node-${NODE_VERSION}/bin/npm /usr/local/bin/npm && \
+    ln -sf /usr/local/node-${NODE_VERSION}/bin/npx /usr/local/bin/npx
+ENV NODE_PATH=/usr/local/node-${NODE_VERSION}/lib/node_modules
+
+# TypeScript + npm globals (split: bumps independently of Node)
+RUN set -xe && \
+    npm install -g --unsafe-perm \
+        typescript@${TYPESCRIPT_VERSION} \
+        @types/node \
+        acorn acorn-walk && \
+    npm cache clean --force
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 9 — Python 3.12 ML interpreter (split from pip install)
+# ════════════════════════════════════════════════════════════════════════
+
+RUN set -xe && \
+    curl -fSsL "https://www.python.org/ftp/python/${PYTHON_ML_VERSION}/Python-${PYTHON_ML_VERSION}.tar.xz" -o /tmp/py.tar.xz && \
+    mkdir /tmp/py && tar -xf /tmp/py.tar.xz -C /tmp/py --strip-components=1 && \
+    cd /tmp/py && \
+    ./configure \
+        --prefix=/usr/local/python-${PYTHON_ML_VERSION} \
+        --enable-optimizations \
+        --with-ensurepip=install && \
+    make -j"$(nproc)" && make -j"$(nproc)" install && \
+    cd / && rm -rf /tmp/py /tmp/py.tar.xz
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 10 — Newton-specific extras (occasional updates)
+# ════════════════════════════════════════════════════════════════════════
+
+# MARS (MIPS) — asset uses major_minor form: Mars4_5.jar for tag v.4.5.1
+RUN set -xe && \
+    mkdir -p /usr/local/mars && \
+    curl -fSsL "https://github.com/dpetersanderson/MARS/releases/download/v.${MARS_VERSION}/Mars4_5.jar" \
+        -o /usr/local/mars/mars.jar && \
+    chmod 755 /usr/local/mars/mars.jar && \
+    printf '%s\n' '.level = SEVERE' > /usr/local/mars/logging.properties
+
+# nand2tetris-web-ide CLI (Newton-owned source — frequent code updates)
+# --force on npm install bypasses the package.json's strict node:20.9.0 pin.
+RUN set -eux; \
+    cd /usr/local/lib && \
+    git clone ${NAND2TETRIS_REPO} nand2tetris-web-ide && \
+    cd nand2tetris-web-ide && \
+    npm install --force && \
+    npm run build && \
+    npm install -g --force ./cli && \
+    ln -sf /usr/local/node-${NODE_VERSION}/bin/nand2tetris /usr/local/bin/nand2tetris
+
+# ════════════════════════════════════════════════════════════════════════
+# Tier 11 — Python 3.12 ML pip install (BOTTOM, most volatile)
+#
+# Course teams add packages here.  This is the one place where
+# "edit-in-place" is the recommended pattern: only this layer rebuilds.
+# Alternatively, append a new RUN below this one for additive package adds.
+# ════════════════════════════════════════════════════════════════════════
+
+RUN /usr/local/python-${PYTHON_ML_VERSION}/bin/pip3 install --no-cache-dir \
+        numpy \
+        pandas \
+        scikit-learn \
+        scipy \
+        matplotlib \
+        seaborn \
+        statsmodels \
+        sympy \
+        mlxtend \
+        xgboost \
+        Pillow \
+        bs4 \
+        gspread \
+        urllib3 \
+        requests \
+        pytest \
+        qiskit \
+        qiskit-aer \
+        qutip
+
+# ════════════════════════════════════════════════════════════════════════
+# Final wiring
+# ════════════════════════════════════════════════════════════════════════
+
+ENV PATH="/usr/local/dotnet-sdk:/usr/local/openjdk-21/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+LABEL maintainer="Gaurav Kapatia <gkapatia@newtonschool.co>" \
+      org.opencontainers.image.source="https://github.com/Newton-School/compilers" \
+      org.opencontainers.image.description="Newton School Judge0 compilers image (v2, modernised)" \
+      org.opencontainers.image.version="0.26"

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -276,7 +276,7 @@ RUN set -xe && \
             curl -fSsL "https://downloads.sourceforge.net/project/freepascal/Linux/${FPC_VERSION}/fpc-${FPC_VERSION}.x86_64-linux.tar" -o /tmp/fpc.tar && \
             mkdir /tmp/fpc && tar -xf /tmp/fpc.tar -C /tmp/fpc --strip-components=1 && \
             cd /tmp/fpc && \
-            echo "/usr/local/fpc-${FPC_VERSION}" | sh install.sh && \
+            echo "/usr/local/fpc-${FPC_VERSION}" | bash install.sh && \
             cd / && rm -rf /tmp/fpc /tmp/fpc.tar \
             ;; \
         arm64) \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -4,22 +4,24 @@
 #
 # - Single Dockerfile (no longer layered on judge0/compilers:1.4.0).
 # - Base: buildpack-deps:bookworm (Debian 12).
-# - One latest-stable per language family, except GCC where 9.5.0 is kept
-#   alongside 14.2.0 to preserve the GCC 9.x compile path for legacy
-#   student submissions.
+# - One latest-stable per language family. GCC pinned to 9.5.0 only — the
+#   modern GCC 14 path was dropped in 0.28 since no production submissions
+#   targeted the new ids.
 # - cgroup v2 only via isolate v2.
 # - Trimmed in 0.27: Clang, .NET, Haskell, Swift, Erlang/Elixir, Lua,
-#   OCaml, Octave, Pascal, GnuCOBOL, GNU Prolog, SBCL, D, Kotlin, Scala,
-#   Groovy, Clojure, PHP — none had meaningful prod usage and they were
-#   ~6-7 GB of image.
+#   OCaml, Octave, Pascal, GnuCOBOL, GNU Prolog, SBCL, D, Groovy, Clojure,
+#   PHP — none had meaningful prod usage.
+# - 0.28: dropped GCC 14.2; Kotlin and Scala re-added at latest stable for
+#   re-introduced course tracks. Plain-text (judge0 id 43) needs no
+#   toolchain and is configured purely on the judge0 side.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
 #
 # Layer ordering: stable-on-top, volatile-on-bottom.
 #   Tier 0: foundation (base/apt/isolate)
-#   Tier 1: GCC (legacy 9.5 + modern 14)
+#   Tier 1: GCC 9.5 (folded into Tier 0 in 0.28)
 #   Tier 2: utility/niche langs (rare bumps) — Bash, NASM, SQLite, FreeBASIC
 #   Tier 3: yearly cadence — R
-#   Tier 4: JVM stack — JDK only
+#   Tier 4: JVM stack — JDK, Kotlin, Scala
 #   Tier 5: yearly mainstream compiled — Go, Rust
 #   Tier 6: yearly mainstream scripting — Ruby, Python default
 #   Tier 7: Node + TypeScript (TypeScript split out, frequent bumps)
@@ -28,16 +30,20 @@
 #   Tier 10: Python ML pip install — most volatile, BOTTOM
 #
 # Cache-friendly editing rules:
+#   - Each language's version pin is an ENV directly above its RUN block.
+#     Bumping a pin invalidates only that ENV layer + the RUN below it
+#     + everything further down — NOT the layers above. This is the
+#     0.28+ structure; pre-0.28 had one mega-ENV at the top that nuked
+#     the whole image on any bump.
 #   - Adding/removing pip pkgs: edit the bottom layer only.
-#   - Bumping a language: cascades to everything below it. Choose pins thoughtfully.
-#   - Adding a new language: APPEND a new RUN at the bottom (above pip install)
-#     so existing cache stays warm.
+#   - Adding a new language: APPEND a new ENV+RUN pair at the bottom
+#     (above pip install) so existing cache stays warm.
 #
 # Multi-arch: amd64 + arm64 supported via TARGETARCH branching.
 # Build:
 #   docker buildx build --platform linux/arm64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     -t newtonschool/judge0-newton-compiler:0.27-arm64 \
+#     -t newtonschool/judge0-newton-compiler:0.28-arm64 \
 #     compilers
 #
 FROM buildpack-deps:bookworm AS base
@@ -45,30 +51,11 @@ FROM buildpack-deps:bookworm AS base
 ARG TARGETARCH
 
 # ────────────────────────────────────────────────────────────────────────
-# Version pins.  WARNING: this ENV layer sits at the top — *any* edit here
-# invalidates the cache for every layer below.  For simple package adds,
-# prefer appending a new RUN at the bottom.
+# Per-language version pins live just above each install RUN, so bumping
+# one language only invalidates that layer (and everything below it),
+# instead of cascading from the top of the file.  The only ENVs here are
+# locale + frontend, which are read by every apt operation that follows.
 # ────────────────────────────────────────────────────────────────────────
-ENV GCC_LEGACY_VERSION=9.5.0 \
-    GCC_VERSION=14.2.0 \
-    PYTHON_VERSION=3.13.1 \
-    PYTHON_ML_VERSION=3.12.7 \
-    RUBY_VERSION=3.3.6 \
-    NODE_VERSION=22.11.0 \
-    TYPESCRIPT_VERSION=5.7.2 \
-    JDK_VERSION=21.0.5+11 \
-    GO_VERSION=1.23.4 \
-    RUST_VERSION=1.83.0 \
-    R_VERSION=4.5.2 \
-    BASH_VERSION=5.2.37 \
-    FBC_VERSION=1.10.1 \
-    NASM_VERSION=2.16.03 \
-    SQLITE_VERSION=3470000 \
-    SQLITE_YEAR=2024 \
-    ISOLATE_REF=v2.0 \
-    NAND2TETRIS_REPO=https://github.com/Newton-School/nand2tetris-web-ide.git \
-    MARS_VERSION=4.5.1
-
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8 \
@@ -128,6 +115,7 @@ RUN set -xe && \
     rm -rf /var/lib/apt/lists/*
 
 # isolate v2 (cgroup v2 sandbox)
+ENV ISOLATE_REF=v2.0
 RUN set -xe && \
     git clone https://github.com/ioi/isolate.git /tmp/isolate && \
     cd /tmp/isolate && \
@@ -137,6 +125,7 @@ RUN set -xe && \
 ENV BOX_ROOT=/var/local/lib/isolate
 
 # GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
+ENV GCC_LEGACY_VERSION=9.5.0
 RUN set -xe && \
     curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
     mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
@@ -155,31 +144,11 @@ RUN set -xe && \
     cd / && rm -rf /tmp/gcc /tmp/gcc-build
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 1 — modern C/C++ toolchains (yearly bumps)
-# ════════════════════════════════════════════════════════════════════════
-
-# GCC 14.2.0 — current default for new submissions
-RUN set -xe && \
-    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
-    mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
-    rm /tmp/gcc.tar.gz && \
-    cd /tmp/gcc && \
-    ./contrib/download_prerequisites && \
-    rm -f *.tar.* && \
-    mkdir /tmp/gcc-build && cd /tmp/gcc-build && \
-    /tmp/gcc/configure \
-        --disable-multilib \
-        --enable-languages=c,c++ \
-        --prefix=/usr/local/gcc-${GCC_VERSION} && \
-    make -j"$(nproc)" && \
-    make -j"$(nproc)" install-strip && \
-    cd / && rm -rf /tmp/gcc /tmp/gcc-build
-
-# ════════════════════════════════════════════════════════════════════════
 # Tier 2 — utility / niche languages (very rare bumps)
 # ════════════════════════════════════════════════════════════════════════
 
 # Bash
+ENV BASH_VERSION=5.2.37
 RUN set -xe && \
     curl -fSsL "https://ftp.gnu.org/gnu/bash/bash-${BASH_VERSION}.tar.gz" -o /tmp/bash.tar.gz && \
     mkdir /tmp/bash && tar -xf /tmp/bash.tar.gz -C /tmp/bash --strip-components=1 && \
@@ -189,6 +158,7 @@ RUN set -xe && \
     cd / && rm -rf /tmp/bash /tmp/bash.tar.gz
 
 # NASM (assembler — amd64 only at runtime, but builds on both arches)
+ENV NASM_VERSION=2.16.03
 RUN set -xe && \
     curl -fSsL "https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/nasm-${NASM_VERSION}.tar.gz" -o /tmp/nasm.tar.gz && \
     mkdir /tmp/nasm && tar -xf /tmp/nasm.tar.gz -C /tmp/nasm --strip-components=1 && \
@@ -203,6 +173,8 @@ RUN set -xe && \
     cd / && rm -rf /tmp/nasm /tmp/nasm.tar.gz
 
 # SQLite
+ENV SQLITE_VERSION=3470000 \
+    SQLITE_YEAR=2024
 RUN set -xe && \
     curl -fSsL "https://www.sqlite.org/${SQLITE_YEAR}/sqlite-autoconf-${SQLITE_VERSION}.tar.gz" -o /tmp/sqlite.tar.gz && \
     mkdir /tmp/sqlite && tar -xf /tmp/sqlite.tar.gz -C /tmp/sqlite --strip-components=1 && \
@@ -223,6 +195,7 @@ RUN set -xe && \
 # NCURSES_TINFO_5.0.19991023 symbol version, which bookworm's libtinfo6
 # does not provide. Install the bullseye libtinfo5 .deb directly so the
 # binary can resolve at runtime.
+ENV FBC_VERSION=1.10.1
 RUN set -xe && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
         curl -fSsL "http://archive.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.2+20201114-2+deb11u2_amd64.deb" -o /tmp/libtinfo5.deb && \
@@ -241,6 +214,7 @@ RUN set -xe && \
 # ════════════════════════════════════════════════════════════════════════
 
 # R (source build + data.table preinstall)
+ENV R_VERSION=4.5.2
 RUN set -xe && \
     curl -fSsL "https://cloud.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz" -o /tmp/r.tar.gz && \
     mkdir /tmp/r && tar -xf /tmp/r.tar.gz -C /tmp/r --strip-components=1 && \
@@ -251,10 +225,11 @@ RUN set -xe && \
     /usr/local/r-${R_VERSION}/bin/Rscript -e 'options(repos="https://cloud.r-project.org"); install.packages("data.table")'
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 4 — JVM stack (JDK only — Kotlin/Scala/Groovy/Clojure dropped in 0.27)
+# Tier 4 — JVM stack (JDK + Kotlin + Scala — Kotlin/Scala re-added in 0.28)
 # ════════════════════════════════════════════════════════════════════════
 
 # OpenJDK 21 LTS (Eclipse Temurin prebuilt)
+ENV JDK_VERSION=21.0.5+11
 RUN set -xe && \
     case "${TARGETARCH}" in \
         amd64) JDK_ARCH=x64 ;; \
@@ -271,11 +246,40 @@ RUN set -xe && \
     ln -sf /usr/local/openjdk-21/bin/jar /usr/local/bin/jar
 ENV JAVA_HOME=/usr/local/openjdk-21
 
+# Kotlin (JetBrains prebuilt; arch-independent JVM toolchain).
+# The release zip extracts to a top-level `kotlinc/` dir; we move its
+# contents into /usr/local/kotlin-${KOTLIN_VERSION}/ so the path matches
+# the version-pinned layout used elsewhere.
+ENV KOTLIN_VERSION=2.3.21
+RUN set -xe && \
+    curl -fSsL "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" -o /tmp/kotlin.zip && \
+    unzip -q /tmp/kotlin.zip -d /tmp/kotlin-extract && \
+    mv /tmp/kotlin-extract/kotlinc /usr/local/kotlin-${KOTLIN_VERSION} && \
+    rm -rf /tmp/kotlin.zip /tmp/kotlin-extract && \
+    ln -sf /usr/local/kotlin-${KOTLIN_VERSION}/bin/kotlinc /usr/local/bin/kotlinc && \
+    ln -sf /usr/local/kotlin-${KOTLIN_VERSION}/bin/kotlin /usr/local/bin/kotlin
+
+# Scala 3 (per-arch prebuilt tarball from scala/scala3 GitHub releases)
+ENV SCALA_VERSION=3.8.3
+RUN set -xe && \
+    case "${TARGETARCH}" in \
+        amd64) SCALA_ARCH=x86_64-pc-linux ;; \
+        arm64) SCALA_ARCH=aarch64-pc-linux ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fSsL "https://github.com/scala/scala3/releases/download/${SCALA_VERSION}/scala3-${SCALA_VERSION}-${SCALA_ARCH}.tar.gz" -o /tmp/scala.tar.gz && \
+    mkdir -p /usr/local/scala-${SCALA_VERSION} && \
+    tar -xf /tmp/scala.tar.gz -C /usr/local/scala-${SCALA_VERSION} --strip-components=1 && \
+    rm /tmp/scala.tar.gz && \
+    ln -sf /usr/local/scala-${SCALA_VERSION}/bin/scala /usr/local/bin/scala && \
+    ln -sf /usr/local/scala-${SCALA_VERSION}/bin/scalac /usr/local/bin/scalac
+
 # ════════════════════════════════════════════════════════════════════════
 # Tier 5 — yearly mainstream compiled (Go, Rust)
 # ════════════════════════════════════════════════════════════════════════
 
 # Go (prebuilt)
+ENV GO_VERSION=1.23.4
 RUN set -xe && \
     case "${TARGETARCH}" in \
         amd64) GO_ARCH=amd64 ;; \
@@ -288,6 +292,7 @@ RUN set -xe && \
     rm /tmp/go.tar.gz
 
 # Rust (prebuilt static toolchain)
+ENV RUST_VERSION=1.83.0
 RUN set -xe && \
     case "${TARGETARCH}" in \
         amd64) RUST_ARCH=x86_64-unknown-linux-gnu ;; \
@@ -306,6 +311,7 @@ RUN set -xe && \
 # ════════════════════════════════════════════════════════════════════════
 
 # Ruby
+ENV RUBY_VERSION=3.3.6
 RUN set -xe && \
     curl -fSsL "https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RUBY_VERSION}.tar.gz" -o /tmp/ruby.tar.gz && \
     mkdir /tmp/ruby && tar -xf /tmp/ruby.tar.gz -C /tmp/ruby --strip-components=1 && \
@@ -317,6 +323,7 @@ RUN set -xe && \
     cd / && rm -rf /tmp/ruby /tmp/ruby.tar.gz
 
 # Python 3.13 (default Python; PGO build)
+ENV PYTHON_VERSION=3.13.1
 RUN set -xe && \
     curl -fSsL "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tar.xz" -o /tmp/py.tar.xz && \
     mkdir /tmp/py && tar -xf /tmp/py.tar.xz -C /tmp/py --strip-components=1 && \
@@ -333,6 +340,7 @@ RUN set -xe && \
 # ════════════════════════════════════════════════════════════════════════
 
 # Node.js (prebuilt tarball, interpreter only)
+ENV NODE_VERSION=22.11.0
 RUN set -xe && \
     case "${TARGETARCH}" in \
         amd64) NODE_ARCH=linux-x64 ;; \
@@ -349,6 +357,7 @@ RUN set -xe && \
 ENV NODE_PATH=/usr/local/node-${NODE_VERSION}/lib/node_modules
 
 # TypeScript + npm globals (split: bumps independently of Node)
+ENV TYPESCRIPT_VERSION=5.7.2
 RUN set -xe && \
     npm install -g --unsafe-perm \
         typescript@${TYPESCRIPT_VERSION} \
@@ -360,6 +369,7 @@ RUN set -xe && \
 # Tier 8 — Python 3.12 ML interpreter (split from pip install)
 # ════════════════════════════════════════════════════════════════════════
 
+ENV PYTHON_ML_VERSION=3.12.7
 RUN set -xe && \
     curl -fSsL "https://www.python.org/ftp/python/${PYTHON_ML_VERSION}/Python-${PYTHON_ML_VERSION}.tar.xz" -o /tmp/py.tar.xz && \
     mkdir /tmp/py && tar -xf /tmp/py.tar.xz -C /tmp/py --strip-components=1 && \
@@ -376,6 +386,7 @@ RUN set -xe && \
 # ════════════════════════════════════════════════════════════════════════
 
 # MARS (MIPS) — asset uses major_minor form: Mars4_5.jar for tag v.4.5.1
+ENV MARS_VERSION=4.5.1
 RUN set -xe && \
     mkdir -p /usr/local/mars && \
     curl -fSsL "https://github.com/dpetersanderson/MARS/releases/download/v.${MARS_VERSION}/Mars4_5.jar" \
@@ -383,12 +394,18 @@ RUN set -xe && \
     chmod 755 /usr/local/mars/mars.jar && \
     printf '%s\n' '.level = SEVERE' > /usr/local/mars/logging.properties
 
-# nand2tetris-web-ide CLI (Newton-owned source — frequent code updates)
+# nand2tetris-web-ide CLI (Newton-owned source — frequent code updates).
+# Pinned to a specific commit so a drive-by push to the upstream repo
+# doesn't silently change image behavior on the next rebuild. Bump
+# NAND2TETRIS_REF intentionally when a new upstream change is wanted.
 # --force on npm install bypasses the package.json's strict node:20.9.0 pin.
+ENV NAND2TETRIS_REPO=https://github.com/Newton-School/nand2tetris-web-ide.git \
+    NAND2TETRIS_REF=b3b5aa6c1844ad5ea4ae881878a5a7e7318977e4
 RUN set -eux; \
     cd /usr/local/lib && \
     git clone ${NAND2TETRIS_REPO} nand2tetris-web-ide && \
     cd nand2tetris-web-ide && \
+    git checkout ${NAND2TETRIS_REF} && \
     npm install --force && \
     npm run build && \
     npm install -g --force ./cli && \
@@ -432,4 +449,4 @@ ENV PATH="/usr/local/openjdk-21/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/us
 LABEL maintainer="Gaurav Kapatia <gkapatia@newtonschool.co>" \
       org.opencontainers.image.source="https://github.com/Newton-School/compilers" \
       org.opencontainers.image.description="Newton School Judge0 compilers image (v2, modernised, trimmed)" \
-      org.opencontainers.image.version="0.27"
+      org.opencontainers.image.version="0.28"

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -259,8 +259,16 @@ RUN set -xe && \
 # name is plain "Binaries-Linux" without spaces. Older Newton Dockerfile
 # revisions used the flat URL with FBC 1.07.1 and worked; for 1.10.1 we
 # need this updated path.
+#
+# FBC 1.10.1's `fbc` binary is linked against libtinfo.so.5 with the
+# NCURSES_TINFO_5.0.19991023 symbol version, which bookworm's libtinfo6
+# does not provide. Install the bullseye libtinfo5 .deb directly so the
+# binary can resolve at runtime.
 RUN set -xe && \
     if [ "${TARGETARCH}" = "amd64" ]; then \
+        curl -fSsL "http://archive.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.2+20201114-2+deb11u2_amd64.deb" -o /tmp/libtinfo5.deb && \
+        dpkg -i /tmp/libtinfo5.deb && \
+        rm /tmp/libtinfo5.deb && \
         curl -fSsL "https://downloads.sourceforge.net/project/fbc/FreeBASIC-${FBC_VERSION}/Binaries-Linux/FreeBASIC-${FBC_VERSION}-linux-x86_64.tar.gz" -o /tmp/fbc.tar.gz && \
         mkdir -p /usr/local/fbc-${FBC_VERSION} && \
         tar -xf /tmp/fbc.tar.gz -C /usr/local/fbc-${FBC_VERSION} --strip-components=1 && \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -124,10 +124,14 @@ RUN set -xe && \
     cd / && rm -rf /tmp/isolate
 ENV BOX_ROOT=/var/local/lib/isolate
 
-# GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
+# GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility).
+# Source pulled from ftp.gnu.org directly, NOT ftpmirror.gnu.org — the
+# auto-redirecting mirror occasionally serves a 403 from inside the
+# buildkit network (same failure mode already documented for Bash in
+# CLAUDE.md pitfall #6).
 ENV GCC_LEGACY_VERSION=9.5.0
 RUN set -xe && \
-    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
+    curl -fSsL "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
     mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
     rm /tmp/gcc.tar.gz && \
     cd /tmp/gcc && \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -124,14 +124,10 @@ RUN set -xe && \
     cd / && rm -rf /tmp/isolate
 ENV BOX_ROOT=/var/local/lib/isolate
 
-# GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility).
-# Source pulled from ftp.gnu.org directly, NOT ftpmirror.gnu.org — the
-# auto-redirecting mirror occasionally serves a 403 from inside the
-# buildkit network (same failure mode already documented for Bash in
-# CLAUDE.md pitfall #6).
+# GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
 ENV GCC_LEGACY_VERSION=9.5.0
 RUN set -xe && \
-    curl -fSsL "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
+    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
     mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
     rm /tmp/gcc.tar.gz && \
     cd /tmp/gcc && \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -8,22 +8,24 @@
 #   alongside 14.2.0 to preserve the GCC 9.x compile path for legacy
 #   student submissions.
 # - cgroup v2 only via isolate v2.
-# - Drops: Python 2.7, Mono, VB.Net.
+# - Trimmed in 0.27: Clang, .NET, Haskell, Swift, Erlang/Elixir, Lua,
+#   OCaml, Octave, Pascal, GnuCOBOL, GNU Prolog, SBCL, D, Kotlin, Scala,
+#   Groovy, Clojure, PHP — none had meaningful prod usage and they were
+#   ~6-7 GB of image.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
 #
 # Layer ordering: stable-on-top, volatile-on-bottom.
 #   Tier 0: foundation (base/apt/isolate)
-#   Tier 1: GCC, Clang
-#   Tier 2: utility/niche langs (rare bumps)
-#   Tier 3: yearly langs (Haskell, OCaml, Erlang, Elixir, R)
-#   Tier 4: JVM stack (JDK, Kotlin, Scala, Groovy, Clojure)
-#   Tier 5: .NET LTS
-#   Tier 6: yearly mainstream compiled (Swift, Go, Rust)
-#   Tier 7: yearly mainstream scripting (PHP, Ruby, Python default)
-#   Tier 8: Node + TypeScript (TypeScript split out, frequent bumps)
-#   Tier 9: Python 3.12 ML interpreter (split from packages)
-#   Tier 10: Newton extras (MARS, nand2tetris)
-#   Tier 11: Python ML pip install — most volatile, BOTTOM
+#   Tier 1: GCC (legacy 9.5 + modern 14)
+#   Tier 2: utility/niche langs (rare bumps) — Bash, NASM, SQLite, FreeBASIC
+#   Tier 3: yearly cadence — R
+#   Tier 4: JVM stack — JDK only
+#   Tier 5: yearly mainstream compiled — Go, Rust
+#   Tier 6: yearly mainstream scripting — Ruby, Python default
+#   Tier 7: Node + TypeScript (TypeScript split out, frequent bumps)
+#   Tier 8: Python 3.12 ML interpreter (split from packages)
+#   Tier 9: Newton extras (MARS, nand2tetris)
+#   Tier 10: Python ML pip install — most volatile, BOTTOM
 #
 # Cache-friendly editing rules:
 #   - Adding/removing pip pkgs: edit the bottom layer only.
@@ -35,7 +37,7 @@
 # Build:
 #   docker buildx build --platform linux/arm64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     -t newtonschool/judge0-newton-compiler:0.26-arm64 \
+#     -t newtonschool/judge0-newton-compiler:0.27-arm64 \
 #     compilers
 #
 FROM buildpack-deps:bookworm AS base
@@ -49,39 +51,20 @@ ARG TARGETARCH
 # ────────────────────────────────────────────────────────────────────────
 ENV GCC_LEGACY_VERSION=9.5.0 \
     GCC_VERSION=14.2.0 \
-    LLVM_VERSION=19 \
     PYTHON_VERSION=3.13.1 \
     PYTHON_ML_VERSION=3.12.7 \
     RUBY_VERSION=3.3.6 \
     NODE_VERSION=22.11.0 \
     TYPESCRIPT_VERSION=5.7.2 \
     JDK_VERSION=21.0.5+11 \
-    KOTLIN_VERSION=2.1.0 \
-    SCALA_VERSION=3.6.2 \
-    GROOVY_VERSION=4.0.24 \
-    CLOJURE_VERSION=1.12.0.1495 \
     GO_VERSION=1.23.4 \
     RUST_VERSION=1.83.0 \
-    PHP_VERSION=8.4.1 \
-    SWIFT_VERSION=6.0.3 \
-    GHC_VERSION=9.10.1 \
-    OCAML_VERSION=5.2.0 \
-    OTP_VERSION=27.1.2 \
-    ELIXIR_VERSION=1.17.3 \
     R_VERSION=4.5.2 \
-    LUA_VERSION=5.4.7 \
-    FPC_VERSION=3.2.2 \
-    SBCL_VERSION=2.4.10 \
-    DMD_VERSION=2.110.0 \
-    LDC_VERSION=1.39.0 \
-    GNUCOBOL_VERSION=3.2 \
-    GPROLOG_VERSION=1.5.0 \
     BASH_VERSION=5.2.37 \
     FBC_VERSION=1.10.1 \
     NASM_VERSION=2.16.03 \
     SQLITE_VERSION=3470000 \
     SQLITE_YEAR=2024 \
-    DOTNET_VERSION=8.0.404 \
     ISOLATE_REF=v2.0 \
     NAND2TETRIS_REPO=https://github.com/Newton-School/nand2tetris-web-ide.git \
     MARS_VERSION=4.5.1
@@ -135,7 +118,6 @@ RUN set -xe && \
         libsystemd-dev \
         libfontconfig1 \
         libgl1 \
-        gfortran \
         pkg-config \
         autoconf \
         automake \
@@ -165,7 +147,7 @@ RUN set -xe && \
     /tmp/gcc/configure \
         --disable-multilib \
         --disable-libsanitizer \
-        --enable-languages=c,c++,fortran \
+        --enable-languages=c,c++ \
         --prefix=/usr/local/gcc-${GCC_LEGACY_VERSION} && \
     make -j"$(nproc)" && \
     make -j"$(nproc)" install-strip && \
@@ -186,26 +168,11 @@ RUN set -xe && \
     mkdir /tmp/gcc-build && cd /tmp/gcc-build && \
     /tmp/gcc/configure \
         --disable-multilib \
-        --enable-languages=c,c++,fortran \
+        --enable-languages=c,c++ \
         --prefix=/usr/local/gcc-${GCC_VERSION} && \
     make -j"$(nproc)" && \
     make -j"$(nproc)" install-strip && \
     cd / && rm -rf /tmp/gcc /tmp/gcc-build
-
-# LLVM/Clang ${LLVM_VERSION} from apt.llvm.org (C, C++, Objective-C)
-RUN set -xe && \
-    curl -fsSL "https://apt.llvm.org/llvm-snapshot.gpg.key" | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg && \
-    echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        clang-${LLVM_VERSION} \
-        lld-${LLVM_VERSION} \
-        libc++-${LLVM_VERSION}-dev \
-        libc++abi-${LLVM_VERSION}-dev \
-        gnustep-devel && \
-    ln -sf /usr/bin/clang-${LLVM_VERSION} /usr/local/bin/clang && \
-    ln -sf /usr/bin/clang++-${LLVM_VERSION} /usr/local/bin/clang++ && \
-    rm -rf /var/lib/apt/lists/*
 
 # ════════════════════════════════════════════════════════════════════════
 # Tier 2 — utility / niche languages (very rare bumps)
@@ -219,15 +186,6 @@ RUN set -xe && \
     ./configure --prefix=/usr/local/bash-${BASH_VERSION} && \
     make -j"$(nproc)" && make install && \
     cd / && rm -rf /tmp/bash /tmp/bash.tar.gz
-
-# Lua
-RUN set -xe && \
-    curl -fSsL "https://www.lua.org/ftp/lua-${LUA_VERSION}.tar.gz" -o /tmp/lua.tar.gz && \
-    mkdir /tmp/lua && tar -xf /tmp/lua.tar.gz -C /tmp/lua --strip-components=1 && \
-    cd /tmp/lua && \
-    make linux -j"$(nproc)" && \
-    make install INSTALL_TOP=/usr/local/lua-${LUA_VERSION} && \
-    cd / && rm -rf /tmp/lua /tmp/lua.tar.gz
 
 # NASM (assembler — amd64 only at runtime, but builds on both arches)
 RUN set -xe && \
@@ -277,151 +235,9 @@ RUN set -xe && \
         echo "FreeBASIC not available for ${TARGETARCH}; skipping" ; \
     fi
 
-# Free Pascal: amd64 prebuilt; arm64 falls back to bookworm apt
-RUN set -xe && \
-    case "${TARGETARCH}" in \
-        amd64) \
-            curl -fSsL "https://downloads.sourceforge.net/project/freepascal/Linux/${FPC_VERSION}/fpc-${FPC_VERSION}.x86_64-linux.tar" -o /tmp/fpc.tar && \
-            mkdir /tmp/fpc && tar -xf /tmp/fpc.tar -C /tmp/fpc --strip-components=1 && \
-            cd /tmp/fpc && \
-            echo "/usr/local/fpc-${FPC_VERSION}" | bash install.sh && \
-            cd / && rm -rf /tmp/fpc /tmp/fpc.tar \
-            ;; \
-        arm64) \
-            apt-get update && \
-            apt-get install -y --no-install-recommends fpc && \
-            rm -rf /var/lib/apt/lists/* && \
-            FPC_APT_VER="$(dpkg-query -W -f='${Version}' fpc | cut -d- -f1 | cut -d+ -f1)" && \
-            mkdir -p /usr/local/fpc-${FPC_APT_VER}/bin && \
-            ln -sf /usr/bin/fpc /usr/local/fpc-${FPC_APT_VER}/bin/fpc \
-            ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
-    esac
-
-# GnuCOBOL
-RUN set -xe && \
-    curl -fSsL "https://ftp.gnu.org/gnu/gnucobol/gnucobol-${GNUCOBOL_VERSION}.tar.xz" -o /tmp/cobol.tar.xz && \
-    mkdir /tmp/cobol && tar -xf /tmp/cobol.tar.xz -C /tmp/cobol --strip-components=1 && \
-    cd /tmp/cobol && \
-    ./configure --prefix=/usr/local/gnucobol-${GNUCOBOL_VERSION} && \
-    make -j"$(nproc)" && make -j"$(nproc)" install && \
-    cd / && rm -rf /tmp/cobol /tmp/cobol.tar.xz
-
-# GNU Prolog
-RUN set -xe && \
-    curl -fSsL "http://gprolog.org/gprolog-${GPROLOG_VERSION}.tar.gz" -o /tmp/gprolog.tar.gz && \
-    mkdir /tmp/gprolog && tar -xf /tmp/gprolog.tar.gz -C /tmp/gprolog --strip-components=1 && \
-    cd /tmp/gprolog/src && \
-    ./configure --prefix=/usr/local/gprolog-${GPROLOG_VERSION} && \
-    make -j"$(nproc)" && make install-strip && \
-    cd / && rm -rf /tmp/gprolog /tmp/gprolog.tar.gz
-
-# SBCL: amd64 prebuilt; arm64 falls back to bookworm apt sbcl
-RUN set -xe && \
-    case "${TARGETARCH}" in \
-        amd64) \
-            curl -fSsL "https://downloads.sourceforge.net/project/sbcl/sbcl/${SBCL_VERSION}/sbcl-${SBCL_VERSION}-x86-64-linux-binary.tar.bz2" -o /tmp/sbcl.tar.bz2 && \
-            mkdir /tmp/sbcl && tar -xf /tmp/sbcl.tar.bz2 -C /tmp/sbcl --strip-components=1 && \
-            cd /tmp/sbcl && \
-            INSTALL_ROOT=/usr/local/sbcl-${SBCL_VERSION} sh install.sh && \
-            cd / && rm -rf /tmp/sbcl /tmp/sbcl.tar.bz2 \
-            ;; \
-        arm64) \
-            apt-get update && \
-            apt-get install -y --no-install-recommends sbcl && \
-            rm -rf /var/lib/apt/lists/* && \
-            SBCL_APT_VER="$(dpkg-query -W -f='${Version}' sbcl | cut -d- -f1)" && \
-            mkdir -p /usr/local/sbcl-${SBCL_APT_VER}/bin /usr/local/sbcl-${SBCL_APT_VER}/lib && \
-            ln -sf /usr/bin/sbcl /usr/local/sbcl-${SBCL_APT_VER}/bin/sbcl && \
-            ln -sf /usr/lib/sbcl /usr/local/sbcl-${SBCL_APT_VER}/lib/sbcl && \
-            ln -sf /usr/local/sbcl-${SBCL_APT_VER} /usr/local/sbcl \
-            ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
-    esac
-
-# D: DMD on amd64, LDC on arm64 (DMD has no arm64 Linux binary)
-RUN set -xe && \
-    case "${TARGETARCH}" in \
-        amd64) \
-            curl -fSsL "https://downloads.dlang.org/releases/2.x/${DMD_VERSION}/dmd.${DMD_VERSION}.linux.tar.xz" -o /tmp/d.tar.xz && \
-            mkdir -p /usr/local/d-${DMD_VERSION} && \
-            tar -xf /tmp/d.tar.xz -C /usr/local/d-${DMD_VERSION} --strip-components=1 && \
-            rm -rf /usr/local/d-${DMD_VERSION}/linux/*32 && \
-            rm /tmp/d.tar.xz \
-            ;; \
-        arm64) \
-            curl -fSsL "https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-linux-aarch64.tar.xz" -o /tmp/ldc.tar.xz && \
-            mkdir -p /usr/local/d-${LDC_VERSION} && \
-            tar -xf /tmp/ldc.tar.xz -C /usr/local/d-${LDC_VERSION} --strip-components=1 && \
-            rm /tmp/ldc.tar.xz && \
-            mkdir -p /usr/local/d-${LDC_VERSION}/linux/bin64 && \
-            ln -sf /usr/local/d-${LDC_VERSION}/bin/ldc2 /usr/local/d-${LDC_VERSION}/linux/bin64/dmd \
-            ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
-    esac
-
-# Octave (apt — bookworm 8.4 ≈ latest 9.x; saves ~30 min vs source build)
-RUN set -xe && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends octave && \
-    rm -rf /var/lib/apt/lists/* && \
-    OCT_PKG_VER="$(dpkg-query -W -f='${Version}' octave | cut -d- -f1)" && \
-    mkdir -p /usr/local/octave-${OCT_PKG_VER}/bin && \
-    ln -sf /usr/bin/octave-cli /usr/local/octave-${OCT_PKG_VER}/bin/octave-cli && \
-    ln -sf /usr/local/octave-${OCT_PKG_VER} /usr/local/octave
-
 # ════════════════════════════════════════════════════════════════════════
-# Tier 3 — yearly-cadence languages (Haskell, OCaml, Erlang, Elixir, R)
+# Tier 3 — yearly-cadence languages (R)
 # ════════════════════════════════════════════════════════════════════════
-
-# Haskell GHC (prebuilt). arm64 has no deb12 build → use deb11 + libtinfo5 shim
-RUN set -xe && \
-    case "${TARGETARCH}" in \
-        amd64) GHC_ARCH=x86_64-deb12-linux ;; \
-        arm64) GHC_ARCH=aarch64-deb11-linux ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    if [ ! -e /usr/lib/aarch64-linux-gnu/libtinfo.so.5 ] && [ -e /usr/lib/aarch64-linux-gnu/libtinfo.so.6 ]; then \
-        ln -sf /usr/lib/aarch64-linux-gnu/libtinfo.so.6 /usr/lib/aarch64-linux-gnu/libtinfo.so.5; \
-    fi && \
-    if [ ! -e /usr/lib/x86_64-linux-gnu/libtinfo.so.5 ] && [ -e /usr/lib/x86_64-linux-gnu/libtinfo.so.6 ]; then \
-        ln -sf /usr/lib/x86_64-linux-gnu/libtinfo.so.6 /usr/lib/x86_64-linux-gnu/libtinfo.so.5; \
-    fi && \
-    curl -fSsL "https://downloads.haskell.org/~ghc/${GHC_VERSION}/ghc-${GHC_VERSION}-${GHC_ARCH}.tar.xz" -o /tmp/ghc.tar.xz && \
-    mkdir /tmp/ghc && tar -xf /tmp/ghc.tar.xz -C /tmp/ghc --strip-components=1 && \
-    cd /tmp/ghc && \
-    ./configure --prefix=/usr/local/ghc-${GHC_VERSION} && \
-    make -j"$(nproc)" install && \
-    cd / && rm -rf /tmp/ghc /tmp/ghc.tar.xz
-
-# OCaml (source)
-RUN set -xe && \
-    curl -fSsL "https://github.com/ocaml/ocaml/archive/refs/tags/${OCAML_VERSION}.tar.gz" -o /tmp/ocaml.tar.gz && \
-    mkdir /tmp/ocaml && tar -xf /tmp/ocaml.tar.gz -C /tmp/ocaml --strip-components=1 && \
-    cd /tmp/ocaml && \
-    ./configure --prefix=/usr/local/ocaml-${OCAML_VERSION} \
-                --disable-ocamldoc --disable-debugger && \
-    make -j"$(nproc)" && make install && \
-    cd / && rm -rf /tmp/ocaml /tmp/ocaml.tar.gz
-
-# Erlang/OTP (source build — slowest layer in this tier, ~15-20 min)
-RUN set -xe && \
-    curl -fSsL "https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" -o /tmp/otp.tar.gz && \
-    mkdir /tmp/otp && tar -xf /tmp/otp.tar.gz -C /tmp/otp --strip-components=1 && \
-    cd /tmp/otp && \
-    ./configure --prefix=/usr/local/erlang-${OTP_VERSION} \
-                --without-javac --without-wx --without-debugger \
-                --without-observer --without-et && \
-    make -j"$(nproc)" && make install && \
-    cd / && rm -rf /tmp/otp /tmp/otp.tar.gz && \
-    ln -sf /usr/local/erlang-${OTP_VERSION}/bin/erl /usr/local/bin/erl
-
-# Elixir (prebuilt for the OTP we just built)
-RUN set -xe && \
-    curl -fSsL "https://github.com/elixir-lang/elixir/releases/download/v${ELIXIR_VERSION}/elixir-otp-${OTP_VERSION%%.*}.zip" -o /tmp/elixir.zip && \
-    mkdir -p /usr/local/elixir-${ELIXIR_VERSION} && \
-    unzip -q /tmp/elixir.zip -d /usr/local/elixir-${ELIXIR_VERSION} && \
-    rm /tmp/elixir.zip
 
 # R (source build + data.table preinstall)
 RUN set -xe && \
@@ -434,7 +250,7 @@ RUN set -xe && \
     /usr/local/r-${R_VERSION}/bin/Rscript -e 'options(repos="https://cloud.r-project.org"); install.packages("data.table")'
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 4 — JVM stack
+# Tier 4 — JVM stack (JDK only — Kotlin/Scala/Groovy/Clojure dropped in 0.27)
 # ════════════════════════════════════════════════════════════════════════
 
 # OpenJDK 21 LTS (Eclipse Temurin prebuilt)
@@ -454,67 +270,9 @@ RUN set -xe && \
     ln -sf /usr/local/openjdk-21/bin/jar /usr/local/bin/jar
 ENV JAVA_HOME=/usr/local/openjdk-21
 
-# Kotlin (JVM, arch-independent zip)
-RUN set -xe && \
-    curl -fSsL "https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip" -o /tmp/kotlin.zip && \
-    unzip -q /tmp/kotlin.zip -d /usr/local/kotlin-${KOTLIN_VERSION} && \
-    mv /usr/local/kotlin-${KOTLIN_VERSION}/kotlinc/* /usr/local/kotlin-${KOTLIN_VERSION}/ && \
-    rmdir /usr/local/kotlin-${KOTLIN_VERSION}/kotlinc && \
-    rm /tmp/kotlin.zip
-
-# Scala 3 (JVM, arch-independent)
-RUN set -xe && \
-    curl -fSsL "https://github.com/scala/scala3/releases/download/${SCALA_VERSION}/scala3-${SCALA_VERSION}.tar.gz" -o /tmp/scala.tar.gz && \
-    mkdir -p /usr/local/scala-${SCALA_VERSION} && \
-    tar -xf /tmp/scala.tar.gz -C /usr/local/scala-${SCALA_VERSION} --strip-components=1 && \
-    rm /tmp/scala.tar.gz
-
-# Groovy (JVM)
-RUN set -xe && \
-    curl -fSsL "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip" -o /tmp/groovy.zip && \
-    unzip -q /tmp/groovy.zip -d /usr/local && \
-    rm /tmp/groovy.zip
-
-# Clojure (JVM, jar via official tools tarball)
-RUN set -xe && \
-    mkdir -p /usr/local/clojure-${CLOJURE_VERSION} && \
-    curl -fSsL "https://github.com/clojure/brew-install/releases/download/${CLOJURE_VERSION}/clojure-tools-${CLOJURE_VERSION}.tar.gz" -o /tmp/clojure.tar.gz && \
-    tar -xf /tmp/clojure.tar.gz -C /tmp && \
-    cp /tmp/clojure-tools/clojure-tools-${CLOJURE_VERSION}.jar /usr/local/clojure-${CLOJURE_VERSION}/clojure.jar && \
-    rm -rf /tmp/clojure-tools /tmp/clojure.tar.gz
-
 # ════════════════════════════════════════════════════════════════════════
-# Tier 5 — .NET (LTS, ~2-year cadence)
+# Tier 5 — yearly mainstream compiled (Go, Rust)
 # ════════════════════════════════════════════════════════════════════════
-
-# .NET 8 SDK (C#, F#) via Microsoft's official install script
-RUN set -xe && \
-    curl -fSsL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh && \
-    bash /tmp/dotnet-install.sh --version ${DOTNET_VERSION} --install-dir /usr/local/dotnet-sdk && \
-    rm /tmp/dotnet-install.sh && \
-    ln -sf /usr/local/dotnet-sdk/dotnet /usr/local/bin/dotnet
-ENV DOTNET_ROOT=/usr/local/dotnet-sdk \
-    DOTNET_NOLOGO=1 \
-    DOTNET_CLI_TELEMETRY_OPTOUT=1
-
-# ════════════════════════════════════════════════════════════════════════
-# Tier 6 — yearly mainstream compiled (Swift, Go, Rust)
-# ════════════════════════════════════════════════════════════════════════
-
-# Swift
-RUN set -xe && \
-    case "${TARGETARCH}" in \
-        amd64) SWIFT_PLATFORM=ubuntu2204 ; SWIFT_ARCH= ;; \
-        arm64) SWIFT_PLATFORM=ubuntu2204-aarch64 ; SWIFT_ARCH=-aarch64 ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends libpython3-dev libxml2 && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -fSsL "https://download.swift.org/swift-${SWIFT_VERSION}-release/${SWIFT_PLATFORM}/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu22.04${SWIFT_ARCH}.tar.gz" -o /tmp/swift.tar.gz && \
-    mkdir -p /usr/local/swift-${SWIFT_VERSION} && \
-    tar -xf /tmp/swift.tar.gz -C /usr/local/swift-${SWIFT_VERSION} --strip-components=2 && \
-    rm /tmp/swift.tar.gz
 
 # Go (prebuilt)
 RUN set -xe && \
@@ -543,23 +301,8 @@ RUN set -xe && \
     cd / && rm -rf /tmp/rust /tmp/rust.tar.gz
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 7 — yearly mainstream scripting (PHP, Ruby, Python default)
+# Tier 6 — yearly mainstream scripting (Ruby, Python default)
 # ════════════════════════════════════════════════════════════════════════
-
-# PHP (build deps installed inline so they don't pollute earlier layers)
-RUN set -xe && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libonig-dev libzip-dev && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -fSsL "https://www.php.net/distributions/php-${PHP_VERSION}.tar.xz" -o /tmp/php.tar.xz && \
-    mkdir /tmp/php && tar -xf /tmp/php.tar.xz -C /tmp/php --strip-components=1 && \
-    cd /tmp/php && \
-    ./configure --prefix=/usr/local/php-${PHP_VERSION} \
-                --with-openssl --with-curl --with-zlib \
-                --enable-mbstring --with-zip && \
-    make -j"$(nproc)" && make -j"$(nproc)" install && \
-    cd / && rm -rf /tmp/php /tmp/php.tar.xz
 
 # Ruby
 RUN set -xe && \
@@ -585,7 +328,7 @@ RUN set -xe && \
     cd / && rm -rf /tmp/py /tmp/py.tar.xz
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 8 — Node + TypeScript (TypeScript split out to isolate npm bumps)
+# Tier 7 — Node + TypeScript (TypeScript split out to isolate npm bumps)
 # ════════════════════════════════════════════════════════════════════════
 
 # Node.js (prebuilt tarball, interpreter only)
@@ -613,7 +356,7 @@ RUN set -xe && \
     npm cache clean --force
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 9 — Python 3.12 ML interpreter (split from pip install)
+# Tier 8 — Python 3.12 ML interpreter (split from pip install)
 # ════════════════════════════════════════════════════════════════════════
 
 RUN set -xe && \
@@ -628,7 +371,7 @@ RUN set -xe && \
     cd / && rm -rf /tmp/py /tmp/py.tar.xz
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 10 — Newton-specific extras (occasional updates)
+# Tier 9 — Newton-specific extras (occasional updates)
 # ════════════════════════════════════════════════════════════════════════
 
 # MARS (MIPS) — asset uses major_minor form: Mars4_5.jar for tag v.4.5.1
@@ -651,7 +394,7 @@ RUN set -eux; \
     ln -sf /usr/local/node-${NODE_VERSION}/bin/nand2tetris /usr/local/bin/nand2tetris
 
 # ════════════════════════════════════════════════════════════════════════
-# Tier 11 — Python 3.12 ML pip install (BOTTOM, most volatile)
+# Tier 10 — Python 3.12 ML pip install (BOTTOM, most volatile)
 #
 # Course teams add packages here.  This is the one place where
 # "edit-in-place" is the recommended pattern: only this layer rebuilds.
@@ -683,9 +426,9 @@ RUN /usr/local/python-${PYTHON_ML_VERSION}/bin/pip3 install --no-cache-dir \
 # Final wiring
 # ════════════════════════════════════════════════════════════════════════
 
-ENV PATH="/usr/local/dotnet-sdk:/usr/local/openjdk-21/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV PATH="/usr/local/openjdk-21/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 LABEL maintainer="Gaurav Kapatia <gkapatia@newtonschool.co>" \
       org.opencontainers.image.source="https://github.com/Newton-School/compilers" \
-      org.opencontainers.image.description="Newton School Judge0 compilers image (v2, modernised)" \
-      org.opencontainers.image.version="0.26"
+      org.opencontainers.image.description="Newton School Judge0 compilers image (v2, modernised, trimmed)" \
+      org.opencontainers.image.version="0.27"

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -5,7 +5,7 @@
 # Runs a tiny "Hello, Newton!" program for every language and reports
 # PASS/FAIL. Designed to be run inside the built container:
 #
-#   docker run --rm -it newtonschool/judge0-newton-compiler:0.27-arm64 \
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.28-arm64 \
 #     bash /work/bin/newton-test
 #
 # Exits non-zero if any language fails, and prints a summary.
@@ -14,6 +14,8 @@
 # Clojure, PHP, Lua, Perl, Swift, Haskell, OCaml, Erlang, Elixir,
 # Pascal, SBCL, D, COBOL, GNU Prolog, .NET — all archived in judge0
 # 0.59+ for low usage.
+# 0.28: dropped GCC 14 C/C++ tests (only GCC 9.5 retained); re-added
+# Kotlin and Scala tests for the re-introduced course tracks.
 #
 set -u
 
@@ -80,7 +82,6 @@ else skip "Bash" "no /usr/local/bash-*"; fi
 section "C / C++"
 # ────────────────────────────────────────────────────────────────────────
 GCC9_DIR="$(resolve '/usr/local/gcc-9.*')"
-GCC_DIR="$(resolve '/usr/local/gcc-1[0-9].*' )"
 
 WRITE_C="printf '%s\n' '#include <stdio.h>' 'int main(void) { printf(\"$EXPECTED\\\\n\"); return 0; }' > main.c"
 WRITE_CPP="printf '%s\n' '#include <iostream>' 'int main() { std::cout << \"$EXPECTED\" << std::endl; return 0; }' > main.cpp"
@@ -89,11 +90,6 @@ if [[ -n "$GCC9_DIR" ]]; then
     t "C (GCC 9.x)" gcc9c "$WRITE_C && $GCC9_DIR/bin/gcc main.c -o a.out && ./a.out"
     t "C++ (GCC 9.x)" gcc9cpp "$WRITE_CPP && $GCC9_DIR/bin/g++ main.cpp -o a.out && LD_LIBRARY_PATH=$GCC9_DIR/lib64 ./a.out"
 else skip "GCC 9.x" "not installed"; fi
-
-if [[ -n "$GCC_DIR" ]]; then
-    t "C (GCC 14.x)" gccc "$WRITE_C && $GCC_DIR/bin/gcc main.c -o a.out && ./a.out"
-    t "C++ (GCC 14.x)" gcccpp "$WRITE_CPP && $GCC_DIR/bin/g++ main.cpp -o a.out && LD_LIBRARY_PATH=$GCC_DIR/lib64 ./a.out"
-else skip "GCC modern" "not installed"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "JVM"
@@ -106,6 +102,26 @@ public class Main { public static void main(String[] a) { System.out.println(\"$
 EOF
         $JDK_DIR/bin/javac Main.java && $JDK_DIR/bin/java Main"
 else skip "Java" "no JDK found"; fi
+
+KOTLIN_DIR="$(resolve '/usr/local/kotlin-*')"
+if [[ -n "$KOTLIN_DIR" ]]; then
+    t "Kotlin" kotlin "
+        cat > Main.kt <<EOF
+fun main() { println(\"$EXPECTED\") }
+EOF
+        $KOTLIN_DIR/bin/kotlinc Main.kt -include-runtime -d Main.jar 2>/dev/null && \
+        $JDK_DIR/bin/java -jar Main.jar"
+else skip "Kotlin" "not installed"; fi
+
+SCALA_DIR="$(resolve '/usr/local/scala-*')"
+if [[ -n "$SCALA_DIR" ]]; then
+    t "Scala" scala "
+        cat > Main.scala <<EOF
+object Main { def main(args: Array[String]): Unit = println(\"$EXPECTED\") }
+EOF
+        $SCALA_DIR/bin/scalac Main.scala 2>/dev/null && \
+        $SCALA_DIR/bin/scala -classpath . Main 2>/dev/null"
+else skip "Scala" "not installed"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "Scripting / interpreted"

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -104,24 +104,28 @@ EOF
 else skip "Java" "no JDK found"; fi
 
 KOTLIN_DIR="$(resolve '/usr/local/kotlin-*')"
-if [[ -n "$KOTLIN_DIR" ]]; then
+if [[ -n "$KOTLIN_DIR" && -n "$JDK_DIR" ]]; then
     t "Kotlin" kotlin "
         cat > Main.kt <<EOF
 fun main() { println(\"$EXPECTED\") }
 EOF
         $KOTLIN_DIR/bin/kotlinc Main.kt -include-runtime -d Main.jar 2>/dev/null && \
         $JDK_DIR/bin/java -jar Main.jar"
-else skip "Kotlin" "not installed"; fi
+else skip "Kotlin" "kotlinc or JDK missing"; fi
 
+# Scala 3.5+ replaced the legacy `scala` runner with a scala-cli launcher
+# that expects sources, not classnames — so we compile with scalac and run
+# directly via java with the Scala stdlib jars on the classpath. This also
+# matches what judge0's run_cmd will invoke in production.
 SCALA_DIR="$(resolve '/usr/local/scala-*')"
-if [[ -n "$SCALA_DIR" ]]; then
+if [[ -n "$SCALA_DIR" && -n "$JDK_DIR" ]]; then
     t "Scala" scala "
         cat > Main.scala <<EOF
 object Main { def main(args: Array[String]): Unit = println(\"$EXPECTED\") }
 EOF
         $SCALA_DIR/bin/scalac Main.scala 2>/dev/null && \
-        $SCALA_DIR/bin/scala -classpath . Main 2>/dev/null"
-else skip "Scala" "not installed"; fi
+        $JDK_DIR/bin/java -cp \"$SCALA_DIR/lib/*:.\" Main"
+else skip "Scala" "scalac or JDK missing"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "Scripting / interpreted"

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -5,10 +5,15 @@
 # Runs a tiny "Hello, Newton!" program for every language and reports
 # PASS/FAIL. Designed to be run inside the built container:
 #
-#   docker run --rm -it newtonschool/judge0-newton-compiler:0.26-arm64 \
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.27-arm64 \
 #     bash /work/bin/newton-test
 #
 # Exits non-zero if any language fails, and prints a summary.
+#
+# 0.27 trim: dropped tests for Clang, Fortran, Kotlin, Scala, Groovy,
+# Clojure, PHP, Lua, Perl, Swift, Haskell, OCaml, Erlang, Elixir,
+# Pascal, SBCL, D, COBOL, GNU Prolog, .NET — all archived in judge0
+# 0.59+ for low usage.
 #
 set -u
 
@@ -72,14 +77,13 @@ if [[ -n "$BASH_DIR" ]]; then
 else skip "Bash" "no /usr/local/bash-*"; fi
 
 # ────────────────────────────────────────────────────────────────────────
-section "C / C++ / Fortran"
+section "C / C++"
 # ────────────────────────────────────────────────────────────────────────
 GCC9_DIR="$(resolve '/usr/local/gcc-9.*')"
 GCC_DIR="$(resolve '/usr/local/gcc-1[0-9].*' )"
 
 WRITE_C="printf '%s\n' '#include <stdio.h>' 'int main(void) { printf(\"$EXPECTED\\\\n\"); return 0; }' > main.c"
 WRITE_CPP="printf '%s\n' '#include <iostream>' 'int main() { std::cout << \"$EXPECTED\" << std::endl; return 0; }' > main.cpp"
-WRITE_F90="printf '%s\n' 'program hello' '  print *, \"$EXPECTED\"' 'end program hello' > main.f90"
 
 if [[ -n "$GCC9_DIR" ]]; then
     t "C (GCC 9.x)" gcc9c "$WRITE_C && $GCC9_DIR/bin/gcc main.c -o a.out && ./a.out"
@@ -89,16 +93,10 @@ else skip "GCC 9.x" "not installed"; fi
 if [[ -n "$GCC_DIR" ]]; then
     t "C (GCC 14.x)" gccc "$WRITE_C && $GCC_DIR/bin/gcc main.c -o a.out && ./a.out"
     t "C++ (GCC 14.x)" gcccpp "$WRITE_CPP && $GCC_DIR/bin/g++ main.cpp -o a.out && LD_LIBRARY_PATH=$GCC_DIR/lib64 ./a.out"
-    t "Fortran (gfortran 14.x)" fortran "$WRITE_F90 && $GCC_DIR/bin/gfortran main.f90 -o a.out && LD_LIBRARY_PATH=$GCC_DIR/lib64 ./a.out"
 else skip "GCC modern" "not installed"; fi
 
-if command -v clang >/dev/null; then
-    t "C (Clang)" clangc "$WRITE_C && clang main.c -o a.out && ./a.out"
-    t "C++ (Clang)" clangcpp "$WRITE_CPP && clang++ main.cpp -o a.out && ./a.out"
-else skip "Clang" "not on PATH"; fi
-
 # ────────────────────────────────────────────────────────────────────────
-section "JVM languages"
+section "JVM"
 # ────────────────────────────────────────────────────────────────────────
 JDK_DIR="$(resolve '/usr/local/openjdk-*')"
 if [[ -n "$JDK_DIR" ]]; then
@@ -108,44 +106,6 @@ public class Main { public static void main(String[] a) { System.out.println(\"$
 EOF
         $JDK_DIR/bin/javac Main.java && $JDK_DIR/bin/java Main"
 else skip "Java" "no JDK found"; fi
-
-KOTLIN_DIR="$(resolve '/usr/local/kotlin-*')"
-if [[ -n "$KOTLIN_DIR" && -n "$JDK_DIR" ]]; then
-    t "Kotlin" kotlin "
-        cat > Main.kt <<EOF
-fun main() { println(\"$EXPECTED\") }
-EOF
-        $KOTLIN_DIR/bin/kotlinc Main.kt -include-runtime -d main.jar 2>/dev/null && \
-        $JDK_DIR/bin/java -jar main.jar"
-else skip "Kotlin" "kotlinc/JDK missing"; fi
-
-SCALA_DIR="$(resolve '/usr/local/scala-*')"
-if [[ -n "$SCALA_DIR" ]]; then
-    t "Scala 3" scala "
-        cat > Main.scala <<EOF
-@main def hello() = println(\"$EXPECTED\")
-EOF
-        $SCALA_DIR/bin/scala-cli run Main.scala 2>/dev/null \
-            || $SCALA_DIR/bin/scala Main.scala"
-else skip "Scala" "no scala dir"; fi
-
-GROOVY_DIR="$(resolve '/usr/local/groovy-*')"
-if [[ -n "$GROOVY_DIR" ]]; then
-    t "Groovy" groovy "
-        cat > script.groovy <<EOF
-println '$EXPECTED'
-EOF
-        $GROOVY_DIR/bin/groovy script.groovy"
-else skip "Groovy" "no groovy dir"; fi
-
-CLOJURE_DIR="$(resolve '/usr/local/clojure-*')"
-if [[ -n "$CLOJURE_DIR" && -n "$JDK_DIR" ]]; then
-    t "Clojure" clojure "
-        cat > main.clj <<EOF
-(println \"$EXPECTED\")
-EOF
-        $JDK_DIR/bin/java -cp $CLOJURE_DIR/clojure.jar clojure.main main.clj"
-else skip "Clojure" "missing deps"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "Scripting / interpreted"
@@ -184,28 +144,8 @@ if [[ -n "$NODE_DIR" ]]; then
         $NODE_DIR/bin/tsc s.ts && $NODE_DIR/bin/node s.js"
 else skip "Node/TS" "not installed"; fi
 
-PHP_DIR="$(resolve '/usr/local/php-*')"
-if [[ -n "$PHP_DIR" ]]; then
-    t "PHP" php "
-        echo '<?php echo \"$EXPECTED\\n\";' > s.php
-        $PHP_DIR/bin/php s.php"
-else skip "PHP" "not installed"; fi
-
-LUA_DIR="$(resolve '/usr/local/lua-*')"
-if [[ -n "$LUA_DIR" ]]; then
-    t "Lua" lua "
-        echo 'print(\"$EXPECTED\")' > s.lua
-        $LUA_DIR/bin/lua s.lua"
-else skip "Lua" "not installed"; fi
-
-if command -v perl >/dev/null; then
-    t "Perl" perl "
-        echo 'print \"$EXPECTED\\n\";' > s.pl
-        perl s.pl"
-else skip "Perl" "not on PATH"; fi
-
 # ────────────────────────────────────────────────────────────────────────
-section "Compiled (non-JVM)"
+section "Compiled"
 # ────────────────────────────────────────────────────────────────────────
 GO_DIR="$(resolve '/usr/local/go-*')"
 if [[ -n "$GO_DIR" ]]; then
@@ -227,131 +167,12 @@ EOF
         $RUST_DIR/bin/rustc main.rs -o main && ./main"
 else skip "Rust" "not installed"; fi
 
-SWIFT_DIR="$(resolve '/usr/local/swift-*')"
-if [[ -n "$SWIFT_DIR" ]]; then
-    t "Swift" swift "
-        cat > Main.swift <<EOF
-print(\"$EXPECTED\")
-EOF
-        $SWIFT_DIR/bin/swiftc Main.swift -o Main && ./Main"
-else skip "Swift" "not installed"; fi
-
-GHC_DIR="$(resolve '/usr/local/ghc-*')"
-if [[ -n "$GHC_DIR" ]]; then
-    t "Haskell GHC" haskell "
-        cat > main.hs <<EOF
-main = putStrLn \"$EXPECTED\"
-EOF
-        $GHC_DIR/bin/ghc -dynamic main.hs -o main 2>/dev/null && ./main"
-else skip "Haskell" "not installed"; fi
-
-OCAML_DIR="$(resolve '/usr/local/ocaml-*')"
-if [[ -n "$OCAML_DIR" ]]; then
-    t "OCaml" ocaml "
-        cat > main.ml <<EOF
-let () = print_endline \"$EXPECTED\"
-EOF
-        $OCAML_DIR/bin/ocamlc main.ml -o main && ./main"
-else skip "OCaml" "not installed"; fi
-
-ERL_DIR="$(resolve '/usr/local/erlang-*')"
-if [[ -n "$ERL_DIR" ]]; then
-    t "Erlang escript" erlang "
-        cat > main.erl <<EOF
-#!/usr/bin/env escript
-main(_) -> io:format(\"$EXPECTED~n\").
-EOF
-        $ERL_DIR/bin/escript main.erl"
-else skip "Erlang" "not installed"; fi
-
-ELIXIR_DIR="$(resolve '/usr/local/elixir-*')"
-if [[ -n "$ELIXIR_DIR" && -n "$ERL_DIR" ]]; then
-    t "Elixir" elixir "
-        echo 'IO.puts(\"$EXPECTED\")' > s.exs
-        PATH=$ERL_DIR/bin:$ELIXIR_DIR/bin:\$PATH $ELIXIR_DIR/bin/elixir s.exs"
-else skip "Elixir" "missing deps"; fi
-
 R_DIR="$(resolve '/usr/local/r-*')"
 if [[ -n "$R_DIR" ]]; then
     t "R" r "
         echo 'cat(\"$EXPECTED\\n\")' > s.r
         $R_DIR/bin/Rscript s.r"
 else skip "R" "not installed"; fi
-
-FPC_DIR="$(resolve '/usr/local/fpc-*')"
-if [[ -n "$FPC_DIR" && -x "$FPC_DIR/bin/fpc" ]]; then
-    t "Free Pascal" pascal "
-        cat > main.pas <<EOF
-program hello;
-begin
-  writeln('$EXPECTED');
-end.
-EOF
-        $FPC_DIR/bin/fpc main.pas >/dev/null && ./main"
-else skip "Pascal" "not installed"; fi
-
-SBCL_DIR="$(resolve '/usr/local/sbcl-*')"
-if [[ -n "$SBCL_DIR" ]]; then
-    t "Common Lisp (SBCL)" sbcl "
-        echo '(write-line \"$EXPECTED\")' > s.lisp
-        SBCL_HOME=$SBCL_DIR/lib/sbcl $SBCL_DIR/bin/sbcl --script s.lisp"
-else skip "SBCL" "not installed"; fi
-
-D_DIR="$(resolve '/usr/local/d-*')"
-if [[ -n "$D_DIR" ]]; then
-    DMD_BIN=""
-    [[ -x "$D_DIR/linux/bin64/dmd" ]] && DMD_BIN="$D_DIR/linux/bin64/dmd"
-    [[ -z "$DMD_BIN" && -x "$D_DIR/bin/ldc2" ]] && DMD_BIN="$D_DIR/bin/ldc2"
-    if [[ -n "$DMD_BIN" ]]; then
-        t "D" dlang "
-            cat > main.d <<EOF
-import std.stdio;
-void main() { writeln(\"$EXPECTED\"); }
-EOF
-            $DMD_BIN main.d -of=main && ./main"
-    else skip "D" "no dmd/ldc2 binary"; fi
-else skip "D" "not installed"; fi
-
-COBOL_DIR="$(resolve '/usr/local/gnucobol-*')"
-if [[ -n "$COBOL_DIR" ]]; then
-    t "COBOL" cobol "
-        cat > main.cob <<EOF
-       IDENTIFICATION DIVISION.
-       PROGRAM-ID. Hello.
-       PROCEDURE DIVISION.
-           DISPLAY \"$EXPECTED\".
-           STOP RUN.
-EOF
-        $COBOL_DIR/bin/cobc -x main.cob -o main && LD_LIBRARY_PATH=$COBOL_DIR/lib ./main"
-else skip "COBOL" "not installed"; fi
-
-GPROLOG_DIR="$(resolve '/usr/local/gprolog-*')"
-if [[ -n "$GPROLOG_DIR" ]]; then
-    GPLC="$(ls -1 $GPROLOG_DIR/bin/gplc $GPROLOG_DIR/gprolog-*/bin/gplc 2>/dev/null | head -n1)"
-    if [[ -n "$GPLC" ]]; then
-        t "GNU Prolog" prolog "
-            cat > main.pro <<EOF
-:- initialization(main).
-main :- write('$EXPECTED'), nl.
-EOF
-            PATH=\$(dirname $GPLC):\$PATH $GPLC --no-top-level main.pro && ./main"
-    else skip "GNU Prolog" "no gplc"; fi
-else skip "GNU Prolog" "not installed"; fi
-
-# ────────────────────────────────────────────────────────────────────────
-section ".NET (C#, F#)"
-# ────────────────────────────────────────────────────────────────────────
-if command -v dotnet >/dev/null; then
-    t "C# (.NET 8)" csharp "
-        mkdir cs && cd cs && \
-        dotnet new console -n Hello --force >/dev/null && \
-        cd Hello && \
-        printf 'System.Console.WriteLine(\"%s\");\\n' '$EXPECTED' > Program.cs && \
-        dotnet run --nologo 2>&1 | grep -v 'Welcome\\|Telemetry\\|\\[\\|---\\|build succeeded' | head -1"
-    t "F# fsi" fsharp "
-        printf 'printfn \"%s\"\\n' '$EXPECTED' > s.fsx && \
-        dotnet fsi s.fsx"
-else skip ".NET" "no dotnet on PATH"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "Architecture-specific / Newton extras"

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+#
+# Newton-owned smoke test for the v2 compilers image.
+#
+# Runs a tiny "Hello, Newton!" program for every language and reports
+# PASS/FAIL. Designed to be run inside the built container:
+#
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.26-arm64 \
+#     bash /work/bin/newton-test
+#
+# Exits non-zero if any language fails, and prints a summary.
+#
+set -u
+
+EXPECTED="Hello, Newton!"
+PASS=0
+FAIL=0
+SKIP=0
+FAILED_LANGS=()
+SKIPPED_LANGS=()
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Resolve a versioned install dir under /usr/local by glob; first match wins.
+resolve() {
+    local pattern="$1"
+    local match
+    match="$(ls -d ${pattern} 2>/dev/null | head -n1)"
+    [[ -n "$match" && -d "$match" ]] && echo "$match"
+}
+
+ARCH="$(uname -m)"
+
+# t <name> <work_subdir> <body>
+#   body should produce stdout. Compared against $EXPECTED.
+t() {
+    local name="$1" sub="$2" body="$3"
+    local d="$WORK/$sub"
+    mkdir -p "$d"
+    pushd "$d" >/dev/null
+    local out
+    out="$(bash -c "$body" 2>&1)"
+    local rc=$?
+    popd >/dev/null
+    if [[ $rc -eq 0 && "$out" == *"$EXPECTED"* ]]; then
+        printf "  \033[32mPASS\033[0m  %s\n" "$name"
+        PASS=$((PASS+1))
+    else
+        printf "  \033[31mFAIL\033[0m  %s  (rc=%d)\n%s\n" "$name" "$rc" "$(echo "$out" | sed 's/^/        /')"
+        FAIL=$((FAIL+1))
+        FAILED_LANGS+=("$name")
+    fi
+}
+
+skip() {
+    local name="$1" reason="$2"
+    printf "  \033[33mSKIP\033[0m  %s  (%s)\n" "$name" "$reason"
+    SKIP=$((SKIP+1))
+    SKIPPED_LANGS+=("$name ($reason)")
+}
+
+section() { printf "\n\033[1m== %s ==\033[0m\n" "$1"; }
+
+# ────────────────────────────────────────────────────────────────────────
+section "Shell / utilities"
+# ────────────────────────────────────────────────────────────────────────
+BASH_DIR="$(resolve '/usr/local/bash-*')"
+if [[ -n "$BASH_DIR" ]]; then
+    t "Bash 5.2" bash \
+      "echo 'echo $EXPECTED' > s.sh && '$BASH_DIR/bin/bash' s.sh"
+else skip "Bash" "no /usr/local/bash-*"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "C / C++ / Fortran"
+# ────────────────────────────────────────────────────────────────────────
+GCC9_DIR="$(resolve '/usr/local/gcc-9.*')"
+GCC_DIR="$(resolve '/usr/local/gcc-1[0-9].*' )"
+
+WRITE_C="printf '%s\n' '#include <stdio.h>' 'int main(void) { printf(\"$EXPECTED\\\\n\"); return 0; }' > main.c"
+WRITE_CPP="printf '%s\n' '#include <iostream>' 'int main() { std::cout << \"$EXPECTED\" << std::endl; return 0; }' > main.cpp"
+WRITE_F90="printf '%s\n' 'program hello' '  print *, \"$EXPECTED\"' 'end program hello' > main.f90"
+
+if [[ -n "$GCC9_DIR" ]]; then
+    t "C (GCC 9.x)" gcc9c "$WRITE_C && $GCC9_DIR/bin/gcc main.c -o a.out && ./a.out"
+    t "C++ (GCC 9.x)" gcc9cpp "$WRITE_CPP && $GCC9_DIR/bin/g++ main.cpp -o a.out && LD_LIBRARY_PATH=$GCC9_DIR/lib64 ./a.out"
+else skip "GCC 9.x" "not installed"; fi
+
+if [[ -n "$GCC_DIR" ]]; then
+    t "C (GCC 14.x)" gccc "$WRITE_C && $GCC_DIR/bin/gcc main.c -o a.out && ./a.out"
+    t "C++ (GCC 14.x)" gcccpp "$WRITE_CPP && $GCC_DIR/bin/g++ main.cpp -o a.out && LD_LIBRARY_PATH=$GCC_DIR/lib64 ./a.out"
+    t "Fortran (gfortran 14.x)" fortran "$WRITE_F90 && $GCC_DIR/bin/gfortran main.f90 -o a.out && LD_LIBRARY_PATH=$GCC_DIR/lib64 ./a.out"
+else skip "GCC modern" "not installed"; fi
+
+if command -v clang >/dev/null; then
+    t "C (Clang)" clangc "$WRITE_C && clang main.c -o a.out && ./a.out"
+    t "C++ (Clang)" clangcpp "$WRITE_CPP && clang++ main.cpp -o a.out && ./a.out"
+else skip "Clang" "not on PATH"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "JVM languages"
+# ────────────────────────────────────────────────────────────────────────
+JDK_DIR="$(resolve '/usr/local/openjdk-*')"
+if [[ -n "$JDK_DIR" ]]; then
+    t "Java (OpenJDK 21)" java "
+        cat > Main.java <<EOF
+public class Main { public static void main(String[] a) { System.out.println(\"$EXPECTED\"); } }
+EOF
+        $JDK_DIR/bin/javac Main.java && $JDK_DIR/bin/java Main"
+else skip "Java" "no JDK found"; fi
+
+KOTLIN_DIR="$(resolve '/usr/local/kotlin-*')"
+if [[ -n "$KOTLIN_DIR" && -n "$JDK_DIR" ]]; then
+    t "Kotlin" kotlin "
+        cat > Main.kt <<EOF
+fun main() { println(\"$EXPECTED\") }
+EOF
+        $KOTLIN_DIR/bin/kotlinc Main.kt -include-runtime -d main.jar 2>/dev/null && \
+        $JDK_DIR/bin/java -jar main.jar"
+else skip "Kotlin" "kotlinc/JDK missing"; fi
+
+SCALA_DIR="$(resolve '/usr/local/scala-*')"
+if [[ -n "$SCALA_DIR" ]]; then
+    t "Scala 3" scala "
+        cat > Main.scala <<EOF
+@main def hello() = println(\"$EXPECTED\")
+EOF
+        $SCALA_DIR/bin/scala-cli run Main.scala 2>/dev/null \
+            || $SCALA_DIR/bin/scala Main.scala"
+else skip "Scala" "no scala dir"; fi
+
+GROOVY_DIR="$(resolve '/usr/local/groovy-*')"
+if [[ -n "$GROOVY_DIR" ]]; then
+    t "Groovy" groovy "
+        cat > script.groovy <<EOF
+println '$EXPECTED'
+EOF
+        $GROOVY_DIR/bin/groovy script.groovy"
+else skip "Groovy" "no groovy dir"; fi
+
+CLOJURE_DIR="$(resolve '/usr/local/clojure-*')"
+if [[ -n "$CLOJURE_DIR" && -n "$JDK_DIR" ]]; then
+    t "Clojure" clojure "
+        cat > main.clj <<EOF
+(println \"$EXPECTED\")
+EOF
+        $JDK_DIR/bin/java -cp $CLOJURE_DIR/clojure.jar clojure.main main.clj"
+else skip "Clojure" "missing deps"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "Scripting / interpreted"
+# ────────────────────────────────────────────────────────────────────────
+PY_DIR="$(resolve '/usr/local/python-3.1[3-9]*')"
+PY_ML_DIR="$(resolve '/usr/local/python-3.12*')"
+
+if [[ -n "$PY_DIR" ]]; then
+    t "Python 3.13" py3 "
+        echo 'print(\"$EXPECTED\")' > s.py
+        $PY_DIR/bin/python3 s.py"
+else skip "Python 3.13" "not installed"; fi
+
+if [[ -n "$PY_ML_DIR" ]]; then
+    t "Python 3.12 ML (interpreter)" pyml "
+        echo 'print(\"$EXPECTED\")' > s.py
+        $PY_ML_DIR/bin/python3 s.py"
+    t "Python 3.12 ML (numpy import)" pymlnumpy "
+        $PY_ML_DIR/bin/python3 -c 'import numpy; print(\"$EXPECTED\")'"
+else skip "Python ML" "not installed"; fi
+
+RUBY_DIR="$(resolve '/usr/local/ruby-*')"
+if [[ -n "$RUBY_DIR" ]]; then
+    t "Ruby" ruby "
+        echo 'puts \"$EXPECTED\"' > s.rb
+        $RUBY_DIR/bin/ruby s.rb"
+else skip "Ruby" "not installed"; fi
+
+NODE_DIR="$(resolve '/usr/local/node-*')"
+if [[ -n "$NODE_DIR" ]]; then
+    t "Node.js" node "
+        echo 'console.log(\"$EXPECTED\")' > s.js
+        $NODE_DIR/bin/node s.js"
+    t "TypeScript" ts "
+        echo 'console.log(\"$EXPECTED\")' > s.ts
+        $NODE_DIR/bin/tsc s.ts && $NODE_DIR/bin/node s.js"
+else skip "Node/TS" "not installed"; fi
+
+PHP_DIR="$(resolve '/usr/local/php-*')"
+if [[ -n "$PHP_DIR" ]]; then
+    t "PHP" php "
+        echo '<?php echo \"$EXPECTED\\n\";' > s.php
+        $PHP_DIR/bin/php s.php"
+else skip "PHP" "not installed"; fi
+
+LUA_DIR="$(resolve '/usr/local/lua-*')"
+if [[ -n "$LUA_DIR" ]]; then
+    t "Lua" lua "
+        echo 'print(\"$EXPECTED\")' > s.lua
+        $LUA_DIR/bin/lua s.lua"
+else skip "Lua" "not installed"; fi
+
+if command -v perl >/dev/null; then
+    t "Perl" perl "
+        echo 'print \"$EXPECTED\\n\";' > s.pl
+        perl s.pl"
+else skip "Perl" "not on PATH"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "Compiled (non-JVM)"
+# ────────────────────────────────────────────────────────────────────────
+GO_DIR="$(resolve '/usr/local/go-*')"
+if [[ -n "$GO_DIR" ]]; then
+    t "Go" go "
+        cat > main.go <<EOF
+package main
+import \"fmt\"
+func main() { fmt.Println(\"$EXPECTED\") }
+EOF
+        GOCACHE=/tmp/.cache/go-build $GO_DIR/bin/go build -o main main.go && ./main"
+else skip "Go" "not installed"; fi
+
+RUST_DIR="$(resolve '/usr/local/rust-*')"
+if [[ -n "$RUST_DIR" ]]; then
+    t "Rust" rust "
+        cat > main.rs <<EOF
+fn main() { println!(\"$EXPECTED\"); }
+EOF
+        $RUST_DIR/bin/rustc main.rs -o main && ./main"
+else skip "Rust" "not installed"; fi
+
+SWIFT_DIR="$(resolve '/usr/local/swift-*')"
+if [[ -n "$SWIFT_DIR" ]]; then
+    t "Swift" swift "
+        cat > Main.swift <<EOF
+print(\"$EXPECTED\")
+EOF
+        $SWIFT_DIR/bin/swiftc Main.swift -o Main && ./Main"
+else skip "Swift" "not installed"; fi
+
+GHC_DIR="$(resolve '/usr/local/ghc-*')"
+if [[ -n "$GHC_DIR" ]]; then
+    t "Haskell GHC" haskell "
+        cat > main.hs <<EOF
+main = putStrLn \"$EXPECTED\"
+EOF
+        $GHC_DIR/bin/ghc -dynamic main.hs -o main 2>/dev/null && ./main"
+else skip "Haskell" "not installed"; fi
+
+OCAML_DIR="$(resolve '/usr/local/ocaml-*')"
+if [[ -n "$OCAML_DIR" ]]; then
+    t "OCaml" ocaml "
+        cat > main.ml <<EOF
+let () = print_endline \"$EXPECTED\"
+EOF
+        $OCAML_DIR/bin/ocamlc main.ml -o main && ./main"
+else skip "OCaml" "not installed"; fi
+
+ERL_DIR="$(resolve '/usr/local/erlang-*')"
+if [[ -n "$ERL_DIR" ]]; then
+    t "Erlang escript" erlang "
+        cat > main.erl <<EOF
+#!/usr/bin/env escript
+main(_) -> io:format(\"$EXPECTED~n\").
+EOF
+        $ERL_DIR/bin/escript main.erl"
+else skip "Erlang" "not installed"; fi
+
+ELIXIR_DIR="$(resolve '/usr/local/elixir-*')"
+if [[ -n "$ELIXIR_DIR" && -n "$ERL_DIR" ]]; then
+    t "Elixir" elixir "
+        echo 'IO.puts(\"$EXPECTED\")' > s.exs
+        PATH=$ERL_DIR/bin:$ELIXIR_DIR/bin:\$PATH $ELIXIR_DIR/bin/elixir s.exs"
+else skip "Elixir" "missing deps"; fi
+
+R_DIR="$(resolve '/usr/local/r-*')"
+if [[ -n "$R_DIR" ]]; then
+    t "R" r "
+        echo 'cat(\"$EXPECTED\\n\")' > s.r
+        $R_DIR/bin/Rscript s.r"
+else skip "R" "not installed"; fi
+
+FPC_DIR="$(resolve '/usr/local/fpc-*')"
+if [[ -n "$FPC_DIR" && -x "$FPC_DIR/bin/fpc" ]]; then
+    t "Free Pascal" pascal "
+        cat > main.pas <<EOF
+program hello;
+begin
+  writeln('$EXPECTED');
+end.
+EOF
+        $FPC_DIR/bin/fpc main.pas >/dev/null && ./main"
+else skip "Pascal" "not installed"; fi
+
+SBCL_DIR="$(resolve '/usr/local/sbcl-*')"
+if [[ -n "$SBCL_DIR" ]]; then
+    t "Common Lisp (SBCL)" sbcl "
+        echo '(write-line \"$EXPECTED\")' > s.lisp
+        SBCL_HOME=$SBCL_DIR/lib/sbcl $SBCL_DIR/bin/sbcl --script s.lisp"
+else skip "SBCL" "not installed"; fi
+
+D_DIR="$(resolve '/usr/local/d-*')"
+if [[ -n "$D_DIR" ]]; then
+    DMD_BIN=""
+    [[ -x "$D_DIR/linux/bin64/dmd" ]] && DMD_BIN="$D_DIR/linux/bin64/dmd"
+    [[ -z "$DMD_BIN" && -x "$D_DIR/bin/ldc2" ]] && DMD_BIN="$D_DIR/bin/ldc2"
+    if [[ -n "$DMD_BIN" ]]; then
+        t "D" dlang "
+            cat > main.d <<EOF
+import std.stdio;
+void main() { writeln(\"$EXPECTED\"); }
+EOF
+            $DMD_BIN main.d -of=main && ./main"
+    else skip "D" "no dmd/ldc2 binary"; fi
+else skip "D" "not installed"; fi
+
+COBOL_DIR="$(resolve '/usr/local/gnucobol-*')"
+if [[ -n "$COBOL_DIR" ]]; then
+    t "COBOL" cobol "
+        cat > main.cob <<EOF
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. Hello.
+       PROCEDURE DIVISION.
+           DISPLAY \"$EXPECTED\".
+           STOP RUN.
+EOF
+        $COBOL_DIR/bin/cobc -x main.cob -o main && LD_LIBRARY_PATH=$COBOL_DIR/lib ./main"
+else skip "COBOL" "not installed"; fi
+
+GPROLOG_DIR="$(resolve '/usr/local/gprolog-*')"
+if [[ -n "$GPROLOG_DIR" ]]; then
+    GPLC="$(ls -1 $GPROLOG_DIR/bin/gplc $GPROLOG_DIR/gprolog-*/bin/gplc 2>/dev/null | head -n1)"
+    if [[ -n "$GPLC" ]]; then
+        t "GNU Prolog" prolog "
+            cat > main.pro <<EOF
+:- initialization(main).
+main :- write('$EXPECTED'), nl.
+EOF
+            PATH=\$(dirname $GPLC):\$PATH $GPLC --no-top-level main.pro && ./main"
+    else skip "GNU Prolog" "no gplc"; fi
+else skip "GNU Prolog" "not installed"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section ".NET (C#, F#)"
+# ────────────────────────────────────────────────────────────────────────
+if command -v dotnet >/dev/null; then
+    t "C# (.NET 8)" csharp "
+        mkdir cs && cd cs && \
+        dotnet new console -n Hello --force >/dev/null && \
+        cd Hello && \
+        printf 'System.Console.WriteLine(\"%s\");\\n' '$EXPECTED' > Program.cs && \
+        dotnet run --nologo 2>&1 | grep -v 'Welcome\\|Telemetry\\|\\[\\|---\\|build succeeded' | head -1"
+    t "F# fsi" fsharp "
+        printf 'printfn \"%s\"\\n' '$EXPECTED' > s.fsx && \
+        dotnet fsi s.fsx"
+else skip ".NET" "no dotnet on PATH"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "Architecture-specific / Newton extras"
+# ────────────────────────────────────────────────────────────────────────
+NASM_DIR="$(resolve '/usr/local/nasm-*')"
+if [[ "$ARCH" == "x86_64" && -n "$NASM_DIR" ]]; then
+    t "NASM (x86_64)" nasm "
+        cat > main.asm <<'EOF'
+section .data
+    msg db \"$EXPECTED\", 10
+    len equ \$ - msg
+section .text
+global _start
+_start:
+    mov rax, 1
+    mov rdi, 1
+    mov rsi, msg
+    mov rdx, len
+    syscall
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+EOF
+        $NASM_DIR/bin/nasm -f elf64 main.asm -o main.o && \
+        ld main.o -o main && ./main"
+else skip "NASM" "arch=$ARCH (amd64-only)"; fi
+
+if [[ "$ARCH" == "x86_64" ]]; then
+    FBC_DIR="$(resolve '/usr/local/fbc-*')"
+    if [[ -n "$FBC_DIR" ]]; then
+        t "FreeBASIC" fbc "
+            echo 'print \"$EXPECTED\"' > main.bas
+            $FBC_DIR/bin/fbc main.bas -x main && ./main"
+    else skip "FreeBASIC" "not installed"; fi
+else skip "FreeBASIC" "arch=$ARCH (amd64-only upstream)"; fi
+
+if [[ -f /usr/local/mars/mars.jar && -n "$JDK_DIR" ]]; then
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "aarch64" ]]; then
+        # MARS is a JAR - architecture-independent. Just check it loads.
+        out="$($JDK_DIR/bin/java -jar /usr/local/mars/mars.jar h 2>&1 | head -1)"
+        if [[ -n "$out" ]]; then
+            printf "  \033[32mPASS\033[0m  MARS (MIPS) jar loads\n"
+            PASS=$((PASS+1))
+        else
+            printf "  \033[31mFAIL\033[0m  MARS\n"
+            FAIL=$((FAIL+1)); FAILED_LANGS+=("MARS")
+        fi
+    fi
+else skip "MARS" "jar or JDK missing"; fi
+
+if command -v nand2tetris >/dev/null; then
+    out="$(nand2tetris --help 2>&1 | head -1)"
+    if [[ -n "$out" ]]; then
+        printf "  \033[32mPASS\033[0m  nand2tetris CLI loads\n"
+        PASS=$((PASS+1))
+    else
+        printf "  \033[31mFAIL\033[0m  nand2tetris\n"
+        FAIL=$((FAIL+1)); FAILED_LANGS+=("nand2tetris")
+    fi
+else skip "nand2tetris" "not installed"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "Sandbox"
+# ────────────────────────────────────────────────────────────────────────
+if command -v isolate >/dev/null; then
+    out="$(isolate --version 2>&1 | head -1)"
+    if [[ "$out" == *"isolator 2."* || "$out" == *"isolate 2."* ]]; then
+        printf "  \033[32mPASS\033[0m  isolate v2  (%s)\n" "$out"
+        PASS=$((PASS+1))
+    else
+        printf "  \033[31mFAIL\033[0m  isolate version unexpected: %s\n" "$out"
+        FAIL=$((FAIL+1)); FAILED_LANGS+=("isolate")
+    fi
+else skip "isolate" "not on PATH"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+echo
+printf "\033[1mSummary:\033[0m  \033[32m%d passed\033[0m, \033[31m%d failed\033[0m, \033[33m%d skipped\033[0m\n" \
+    "$PASS" "$FAIL" "$SKIP"
+if (( FAIL > 0 )); then
+    printf "\nFailed: %s\n" "${FAILED_LANGS[*]}"
+fi
+if (( SKIP > 0 )); then
+    printf "\nSkipped:\n"
+    for s in "${SKIPPED_LANGS[@]}"; do printf "  - %s\n" "$s"; done
+fi
+
+(( FAIL == 0 ))


### PR DESCRIPTION
## Summary

Two milestones in one PR:

- **0.26 — modernise.** Replace the layered `judge0/compilers:1.4.0` + `NewtonDockerfile-v1` stack with a single Dockerfile based on `buildpack-deps:bookworm` (Debian 12). Every language at latest stable, isolate v2 (cgroup-v2 capable), GCC 9.5 + 14 dual.
- **0.27 — trim.** Drop 18 toolchains driven by prod usage data (<100 playgrounds each, often 0). Image goes from ~14 GB → 6.75 GB on arm64. Build time drops from ~75 min → ~30-45 min on c6i.4xlarge.

## What changes (0.26 — modernise)

- **Base** `buildpack-deps:buster (2019-12-28 snapshot)` → **`buildpack-deps:bookworm`**. Drops the `archive.debian.org` sources.list workaround.
- **One latest-stable per language**, with `GCC 9.5.0` kept alongside `GCC 14.2.0` for legacy compile paths.
- **isolate** bumped to v2.x — cgroup v2 capable. The Newton judge0 image's `docker-entrypoint.sh` provides the cgroup hierarchy isolate v2 needs (substituting for `isolate-cg-keeper.service` in non-systemd containers).
- **Drops** Python 2.7, Mono, VB.Net (Python 2 EOL since 2020; .NET 8 took C#/F#'s place but later archived in judge0 0.57).
- **Multi-arch**: amd64 and arm64 via `TARGETARCH`. arm64 falls back to bookworm apt for SBCL and FPC, uses LDC instead of DMD.

### Version table (0.26)

| Language | Was | Now |
|---|---|---|
| Base | buster (2019) | bookworm |
| GCC | 7.4 / 8.3 / 9.2 | **9.5.0 + 14.2.0** |
| Python | 2.7.17 + 3.11.4 | **3.13.1** + **3.12.7 ML** |
| Node | 20.9.0 | **22.11.0** LTS |
| Java | OpenJDK 13 | **OpenJDK 21 LTS** |
| Ruby | 2.7.0 | **3.3.6** |
| Go | 1.13.5 | **1.23.4** |
| Rust | 1.40.0 | **1.83.0** |
| isolate | 2019 SHA | **v2.0** (cgroup v2 capable) |

## What changes (0.27 — trim)

Driven by prod usage data — every active toolchain that backed <100 playgrounds was dropped.

**Dropped from the image:**
- Clang/LLVM (judge0 ids 75, 76, 79)
- .NET 8 SDK + dotnet-script (judge0 ids 51, 87)
- Haskell GHC (~3 GB by itself, id 61)
- Swift (id 83)
- Erlang/OTP + Elixir (ids 58, 57)
- OCaml (id 65)
- Octave (id 66)
- Free Pascal / FPC (id 67)
- GnuCOBOL (id 77)
- GNU Prolog (id 69)
- SBCL (id 55)
- DMD/LDC for D (id 56)
- Lua (id 64)
- PHP (id 68)
- Kotlin (id 78)
- Scala 3 (id 81)
- Groovy (id 88)
- Clojure (id 86)

`gfortran` is also dropped from `--enable-languages` on both GCC builds (Fortran id 59 was archived).

**Retained:** GCC 9.5 + 14.2 (C/C++), Java 21, Python 3.13 + 3.12 ML, Ruby 3.3.6, Node 22 + TypeScript, Go 1.23, Rust 1.83, R 4.5, Bash 5.2, NASM, FreeBASIC, SQLite, MARS, nand2tetris, isolate v2.

## Layer ordering

Stable on top, volatile on bottom. Python ML pip install is at the very bottom, isolated to one layer — package adds only invalidate that layer.

## Smoke-test results (`bin/newton-test` against the built image)

```
arm64 (locally validated, 0.27-arm64):  18 PASS / 0 FAIL / 2 SKIP
                                        (NASM + FreeBASIC are amd64-only upstream)
amd64 (EC2, validated, 0.27):          19 PASS / 0 FAIL / 0 SKIP
```

## Build commands

```bash
# arm64 (Mac dev)
docker buildx build --platform linux/arm64 \
  -f NewtonDockerFiles/NewtonDockerfile-v2 \
  -t newtonschool/judge0-newton-compiler:0.27-arm64 \
  --load .

# amd64 (EC2 / prod)
docker buildx build --platform linux/amd64 \
  -f NewtonDockerFiles/NewtonDockerfile-v2 \
  -t newtonschool/judge0-newton-compiler:0.27 \
  --load .
```

## Image size

| Tag | Size (arm64) |
|---|---|
| 0.26-arm64 | ~14 GB |
| **0.27-arm64** | **6.75 GB** |

**~52% reduction.**

## Published images

Both arches on Docker Hub:
- `newtonschool/judge0-newton-compiler:0.27` (amd64)
- `newtonschool/judge0-newton-compiler:0.27-arm64`

## Test plan

- [x] arm64 build locally — 18/0/2
- [x] amd64 build on EC2 — 19/0/0
- [x] Push to Docker Hub
- [x] Phase 2/3 (judge0) PR builds + smoke-tests on top — see [Newton-School/judge0#26](https://github.com/Newton-School/judge0/pull/26)
- [x] judge0 0.60 image (consuming this) verified end-to-end on K8s staging in cgroup-v2 mode

## Follow-ups

None planned for this image. C# / F# stay archived in judge0 0.59+ (rlimit + cgroup-mode RSS-only memory accounting still excludes .NET CoreCLR's RLIMIT_FSIZE-on-JIT-write requirement; the team is not pursuing further infra to host it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
