### PR TITLE
0.32: tag bump + tighten .NET 7/8 smoke flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Base Docker image that ships every language toolchain Judge0 executes
 student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
-upstream artifact) and `newtonschool/judge0-newton-compiler:0.30+` (Newton's
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.32` (Newton's
 modernised + trimmed artifact, which is what `Newton-School/judge0` actually
 consumes).
 
@@ -11,7 +11,7 @@ consumes).
 GCC 9.5 (C/C++), Java 21, Kotlin 2.3.21, Scala 3.8.3, Python 3.13 + 3.12 ML,
 Ruby 3.3.6, Node 22 + TypeScript, Go 1.23, Rust 1.83, R 4.5, Bash 5.2,
 NASM (amd64-only), FreeBASIC (amd64-only), SQLite, MARS, nand2tetris,
-Icarus Verilog 13.0, Mono 6.12 + .NET 8 + .NET 10 (C# lanes), isolate v2.
+Icarus Verilog 13.0, Mono 6.12 + .NET 7 + .NET 8 (C# lanes), isolate v2.
 
 Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
 
@@ -33,13 +33,17 @@ Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
   layer) — pure C/C++ source build, no per-arch branching. Backs judge0
   language id 3005. Build deps (autoconf/gperf/flex/bison) are installed
   and purged in the same RUN.
-- **C# / .NET lives in Tier 12** (added in 0.30, bottom of the file).
-  Mono 6.12.0.122 is a from-source build into `/usr/local/mono-<ver>`
-  (legacy `.NET Framework 4.7`-era compat); .NET 8.0.420 and .NET 10.0.202
-  SDKs install side-by-side into `/usr/local/dotnet-sdk` via the official
-  `dotnet-install.sh`, with `DOTNET_ROOT` set and `DOTNET_MULTILEVEL_LOOKUP=0`.
-  Per-test SDK selection is via a `global.json` (`rollForward: disable`).
-  `mono`, `mcs`, and `dotnet` are symlinked into `/usr/local/bin`.
+- **C# / .NET lives in Tier 12** (added in 0.30, retuned in 0.32). Mono
+  6.12.0.122 is a from-source build into `/usr/local/mono-<ver>` (legacy
+  `.NET Framework 4.7`-era compat); .NET 7.0.400 (hiring courses target
+  net7.0) and .NET 8.0.302 SDKs install side-by-side into
+  `/usr/local/dotnet-sdk` via the official `dotnet-install.sh`, with
+  `DOTNET_ROOT` set and `DOTNET_MULTILEVEL_LOOKUP=0`. Telemetry/first-run
+  noise suppressed via `DOTNET_NOLOGO=1`,
+  `DOTNET_CLI_TELEMETRY_OPTOUT=1`, `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1`
+  in the same ENV. Per-test SDK selection is via a `global.json`
+  (`rollForward: disable`). `mono`, `mcs`, and `dotnet` are symlinked
+  into `/usr/local/bin`.
 
 See `git log` for the 0.26 → 0.30 trim/revive chronology if you need to know
 when a particular toolchain came or went.
@@ -75,7 +79,10 @@ when a particular toolchain came or went.
   the GCC 9.x ABI/diagnostic surface. ids 3003/3004 (GCC 14 C/C++) are
   archived on the judge0 side.
 - Drops: Python 2.7, VB.Net. (Mono was dropped in 0.27 and re-added in
-  0.30 alongside .NET 8 / .NET 10 SDKs for hiring-course C# coverage.)
+  0.30 for hiring-course C# coverage. 0.32 swapped the side-by-side SDKs
+  from .NET 8 + .NET 10 to .NET 7 + .NET 8 — net7.0 is the hiring-course
+  target. .NET 7 is out of Microsoft support since May 2024; pin is
+  intentional and locked via `global.json` rollForward: disable.)
 - Multi-arch (amd64 + arm64) via `ARG TARGETARCH` branching. arm64 falls
   back to bookworm `apt sbcl` and `apt fpc` (no upstream binaries) and
   uses LDC instead of DMD.
@@ -99,13 +106,13 @@ image (45+ min lost to this on the JDK pin in 0.26 — don't recreate it).
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.30-arm64 \
+  -t newtonschool/judge0-newton-compiler:0.32-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.30 \
+  -t newtonschool/judge0-newton-compiler:0.32 \
   --load .
 ```
 
@@ -118,11 +125,11 @@ drops.
 ```bash
 docker run --rm \
   -v "$PWD/bin:/work/bin:ro" \
-  newtonschool/judge0-newton-compiler:0.30-arm64 \
+  newtonschool/judge0-newton-compiler:0.32-arm64 \
   bash /work/bin/newton-test
 ```
 
-Expected (post 0.30: 3 C# lanes added — Mono legacy, .NET 8, .NET 10):
+Expected (post 0.32: 3 C# lanes — Mono legacy, .NET 7, .NET 8):
 22 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and FreeBASIC are amd64-only
 upstream and skip on arm64). 24 PASS / 0 FAIL / 0 SKIP on amd64.
 
@@ -166,7 +173,7 @@ If this isn't green, DON'T tag/push.
 ## Image is published as
 
 - Docker Hub: `newtonschool/judge0-newton-compiler`
-- Current tag: **`0.30`** (amd64 produced on EC2). Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29.
+- Current tag: **`0.32`** (amd64 produced on EC2). Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31.
 
 ## Production deploys
 

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -14,8 +14,10 @@
 # - 0.28: dropped GCC 14.2; Kotlin and Scala re-added at latest stable for
 #   re-introduced course tracks. Plain-text (judge0 id 43) needs no
 #   toolchain and is configured purely on the judge0 side.
-# - 0.30+: restore C# lanes for hiring-course coverage: Mono 6.12 (legacy
-#   compatibility) plus side-by-side .NET Core SDK 7.0.400 and 8.0.302.
+# - 0.30: restore C# lanes for hiring-course coverage: Mono 6.12 (legacy
+#   4.7-era compatibility) plus side-by-side .NET 8 and .NET 10 SDKs.
+# - 0.32: swap .NET 10 for .NET 7 (hiring courses target net7.0); .NET 8
+#   patch downshifted to 8.0.302. Lanes now: Mono 6.12 + .NET 7 + .NET 8.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
 #
 # Layer ordering: stable-on-top, volatile-on-bottom.

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -162,20 +162,18 @@ EOF
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 </Project>
 EOF
-        cat > Program.cs <<'EOF'
+        cat > Main.cs <<'EOF'
 using System;
 using System.Linq;
 
 Console.WriteLine(string.Join(\", \", new[] { \"Hello\", \"Newton!\" }.Select(x => x)));
 EOF
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj --framework net7.0 -nologo -o out >/dev/null && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet out/Main.dll"
+        mkdir -p ~/.dotnet && touch ~/.dotnet/${DOTNET7_VERSION}.dotnetFirstUseSentinel && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
 else skip "C# (.NET Core 7)" "dotnet or DOTNET7_VERSION missing"; fi
 
 if command -v dotnet >/dev/null && [[ -n "${DOTNET8_VERSION:-}" ]]; then
@@ -189,20 +187,18 @@ EOF
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 </Project>
 EOF
-        cat > Program.cs <<'EOF'
+        cat > Main.cs <<'EOF'
 using System;
 using System.Linq;
 
 Console.WriteLine(string.Join(\", \", new[] { \"Hello\", \"Newton!\" }.Select(x => x)));
 EOF
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj --framework net8.0 -nologo -o out >/dev/null && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet out/Main.dll"
+        mkdir -p ~/.dotnet && touch ~/.dotnet/${DOTNET8_VERSION}.dotnetFirstUseSentinel && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
 else skip "C# (.NET Core 8)" "dotnet or DOTNET8_VERSION missing"; fi
 
 # ────────────────────────────────────────────────────────────────────────

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -5,7 +5,7 @@
 # Runs a tiny "Hello, Newton!" program for every language and reports
 # PASS/FAIL. Designed to be run inside the built container:
 #
-#   docker run --rm -it newtonschool/judge0-newton-compiler:0.30-arm64 \
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.32-arm64 \
 #     bash /work/bin/newton-test
 #
 # Exits non-zero if any language fails, and prints a summary.
@@ -16,7 +16,9 @@
 # 0.59+ for low usage.
 # 0.28: dropped GCC 14 C/C++ tests (only GCC 9.5 retained); re-added
 # Kotlin and Scala tests for the re-introduced course tracks.
-# 0.30+: restored C# coverage via Mono 6.12 plus .NET Core 7 and 8.
+# 0.30: restored C# coverage via Mono 6.12 plus .NET 8 and .NET 10.
+# 0.32: swapped .NET 10 for .NET Core 7 (hiring courses need net7.0
+# target compat); .NET 8 patch downshifted to 8.0.302.
 #
 set -u
 
@@ -160,18 +162,20 @@ EOF
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 </Project>
 EOF
-        cat > Main.cs <<'EOF'
+        cat > Program.cs <<'EOF'
 using System;
 using System.Linq;
 
 Console.WriteLine(string.Join(\", \", new[] { \"Hello\", \"Newton!\" }.Select(x => x)));
 EOF
-        mkdir -p ~/.dotnet && touch ~/.dotnet/${DOTNET7_VERSION}.dotnetFirstUseSentinel && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj --framework net7.0 -nologo -o out >/dev/null && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet out/Main.dll"
 else skip "C# (.NET Core 7)" "dotnet or DOTNET7_VERSION missing"; fi
 
 if command -v dotnet >/dev/null && [[ -n "${DOTNET8_VERSION:-}" ]]; then
@@ -185,18 +189,20 @@ EOF
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 </Project>
 EOF
-        cat > Main.cs <<'EOF'
+        cat > Program.cs <<'EOF'
 using System;
 using System.Linq;
 
 Console.WriteLine(string.Join(\", \", new[] { \"Hello\", \"Newton!\" }.Select(x => x)));
 EOF
-        mkdir -p ~/.dotnet && touch ~/.dotnet/${DOTNET8_VERSION}.dotnetFirstUseSentinel && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj -nologo >/dev/null && \
-        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet run --no-build --project Main.csproj"
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet build Main.csproj --framework net8.0 -nologo -o out >/dev/null && \
+        DOTNET_CLI_HOME=\"$PWD/.dotnet-home\" dotnet out/Main.dll"
 else skip "C# (.NET Core 8)" "dotnet or DOTNET8_VERSION missing"; fi
 
 # ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #13. Three classes of cleanup that didn't make it into the merge:

- **Tag references**: bump `0.30` / `0.30+` → `0.32` across `CLAUDE.md`, `NewtonDockerfile-v2` changelog, and `bin/newton-test` so downstream pins (`newtonschool/judge0-newton-compiler:0.32`) and the per-version changelog comments match the actual published prod image.
- **Dockerfile changelog split**: discrete `0.30` (initial Mono + .NET 8 + .NET 10 add) and `0.32` (swap .NET 10 → .NET 7, downshift .NET 8 patch) entries — `git blame` and the inline comments stay in sync.
- **Smoke flow hardening** in `bin/newton-test`:
  - Restored deterministic `dotnet build --framework netX.0 -nologo -o out` + `dotnet out/Main.dll` (the `dotnet run --no-build --project` form was fragile under `global.json` rollForward quirks).
  - Restored csproj hardening that got lost in #13: `ImplicitUsings=disable`, `Nullable=disable`, **`UseAppHost=false`**. The last one matters under isolate — without it `dotnet build` produces a per-platform apphost binary alongside the DLL that can misbehave in the sandbox.
  - Dropped the `mkdir -p ~/.dotnet && touch ~/.dotnet/${DOTNET*_VERSION}.dotnetFirstUseSentinel` lines. `DOTNET_NOLOGO=1` and `DOTNET_CLI_TELEMETRY_OPTOUT=1` are already set in `NewtonDockerfile-v2` (lines 517-521), so the sentinel touch was dead code.
- **CLAUDE.md**: documented that the .NET 7 EOL pin is intentional (hiring courses target `net7.0`) and that the suppression env vars live in the Dockerfile Tier 12 block.

## Why .NET 7 stays despite EOL

.NET 7 went out of Microsoft support on May 14, 2024. Hiring-course problem sets target `net7.0` specifically and the pin is locked via `global.json` `rollForward: disable`, so it won't silently bump. Documented inline in CLAUDE.md so future maintainers don't bump it away on cleanup pass.

## Test plan

- [x] `bash -n bin/newton-test` — syntax check clean
- [ ] Build `newtonschool/judge0-newton-compiler:0.32-arm64` locally and run `bin/newton-test` inside — expect 22 PASS / 0 FAIL / 2 SKIP on arm64
- [ ] Build amd64 on EC2, smoke-test, then tag/push `0.32` to Docker Hub
- [ ] Confirm Judge0 `compile_cmd` for net7.0 / net8.0 lanes still passes `UseAppHost=false` explicitly (smoke now matches what we want prod to do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)