### PR TITLE
0.33: DOTNET_EnableWriteXorExecute=0 — fix SIGXFSZ from .NET W^X allocator under isolate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Base Docker image that ships every language toolchain Judge0 executes
 student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
-upstream artifact) and `newtonschool/judge0-newton-compiler:0.32` (Newton's
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.33` (Newton's
 modernised + trimmed artifact, which is what `Newton-School/judge0` actually
 consumes).
 
@@ -33,17 +33,29 @@ Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
   layer) — pure C/C++ source build, no per-arch branching. Backs judge0
   language id 3005. Build deps (autoconf/gperf/flex/bison) are installed
   and purged in the same RUN.
-- **C# / .NET lives in Tier 12** (added in 0.30, retuned in 0.32). Mono
-  6.12.0.122 is a from-source build into `/usr/local/mono-<ver>` (legacy
-  `.NET Framework 4.7`-era compat); .NET 7.0.400 (hiring courses target
-  net7.0) and .NET 8.0.302 SDKs install side-by-side into
-  `/usr/local/dotnet-sdk` via the official `dotnet-install.sh`, with
-  `DOTNET_ROOT` set and `DOTNET_MULTILEVEL_LOOKUP=0`. Telemetry/first-run
-  noise suppressed via `DOTNET_NOLOGO=1`,
-  `DOTNET_CLI_TELEMETRY_OPTOUT=1`, `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1`
-  in the same ENV. Per-test SDK selection is via a `global.json`
-  (`rollForward: disable`). `mono`, `mcs`, and `dotnet` are symlinked
-  into `/usr/local/bin`.
+- **C# / .NET lives in Tier 12** (added in 0.30, retuned in 0.32, W^X
+  workaround added in 0.33). Mono 6.12.0.122 is a from-source build into
+  `/usr/local/mono-<ver>` (legacy `.NET Framework 4.7`-era compat); .NET
+  7.0.400 (hiring courses target net7.0) and .NET 8.0.302 SDKs install
+  side-by-side into `/usr/local/dotnet-sdk` via the official
+  `dotnet-install.sh`, with `DOTNET_ROOT` set and
+  `DOTNET_MULTILEVEL_LOOKUP=0`. Telemetry/first-run noise suppressed via
+  `DOTNET_NOLOGO=1`, `DOTNET_CLI_TELEMETRY_OPTOUT=1`,
+  `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1` in the same ENV. Per-test SDK
+  selection is via a `global.json` (`rollForward: disable`). `mono`,
+  `mcs`, and `dotnet` are symlinked into `/usr/local/bin`.
+- **`DOTNET_EnableWriteXorExecute=0` is intentional** (added in 0.33).
+  .NET 6+ on Linux uses a W^X double-mapped JIT code allocator that
+  calls `memfd_create` + `ftruncate` to a reservation derived from host
+  RAM. On large-RAM hosts (EC2 prod) the reservation exceeds isolate's
+  `RLIMIT_FSIZE` (capped at ~1-2 GiB by Judge0's `MAX_MAX_FILE_SIZE`),
+  causing `ftruncate` to fail with EFBIG → SIGXFSZ → dotnet dies during
+  runtime init, before any user-visible output. Diagnostic fingerprint:
+  `exit 153` (= 128 + 25) with zero stdout/stderr on compile. Disabling
+  W^X uses a single RWX mapping instead — fine inside isolate which
+  already provides the security boundary. Judge0's `IsolateJob` must
+  propagate this env via `-E DOTNET_EnableWriteXorExecute` (isolate
+  strips env by default).
 
 See `git log` for the 0.26 → 0.30 trim/revive chronology if you need to know
 when a particular toolchain came or went.
@@ -106,13 +118,13 @@ image (45+ min lost to this on the JDK pin in 0.26 — don't recreate it).
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.32-arm64 \
+  -t newtonschool/judge0-newton-compiler:0.33-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.32 \
+  -t newtonschool/judge0-newton-compiler:0.33 \
   --load .
 ```
 
@@ -125,11 +137,11 @@ drops.
 ```bash
 docker run --rm \
   -v "$PWD/bin:/work/bin:ro" \
-  newtonschool/judge0-newton-compiler:0.32-arm64 \
+  newtonschool/judge0-newton-compiler:0.33-arm64 \
   bash /work/bin/newton-test
 ```
 
-Expected (post 0.32: 3 C# lanes — Mono legacy, .NET 7, .NET 8):
+Expected (post 0.33: 3 C# lanes — Mono legacy, .NET 7, .NET 8):
 22 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and FreeBASIC are amd64-only
 upstream and skip on arm64). 24 PASS / 0 FAIL / 0 SKIP on amd64.
 
@@ -173,7 +185,7 @@ If this isn't green, DON'T tag/push.
 ## Image is published as
 
 - Docker Hub: `newtonschool/judge0-newton-compiler`
-- Current tag: **`0.32`** (amd64 produced on EC2). Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31.
+- Current tag: **`0.33`** (amd64 produced on EC2). Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32.
 
 ## Production deploys
 

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -18,6 +18,12 @@
 #   4.7-era compatibility) plus side-by-side .NET 8 and .NET 10 SDKs.
 # - 0.32: swap .NET 10 for .NET 7 (hiring courses target net7.0); .NET 8
 #   patch downshifted to 8.0.302. Lanes now: Mono 6.12 + .NET 7 + .NET 8.
+# - 0.33: add DOTNET_EnableWriteXorExecute=0 to the Tier 12 ENV block.
+#   .NET 6+ W^X double-mapped JIT allocator calls memfd_create + ftruncate
+#   to a host-RAM-derived reservation that exceeds isolate's RLIMIT_FSIZE
+#   on large hosts (EC2), killing dotnet with SIGXFSZ during runtime init.
+#   Disabling W^X uses a single RWX mapping; safe inside isolate which
+#   already provides the security boundary.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
 #
 # Layer ordering: stable-on-top, volatile-on-bottom.
@@ -520,7 +526,8 @@ ENV DOTNET_ROOT=/usr/local/dotnet-sdk \
     DOTNET_NOLOGO=1 \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
-    DOTNET_MULTILEVEL_LOOKUP=0
+    DOTNET_MULTILEVEL_LOOKUP=0 \
+    DOTNET_EnableWriteXorExecute=0
 
 # ════════════════════════════════════════════════════════════════════════
 # Final wiring

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -5,7 +5,7 @@
 # Runs a tiny "Hello, Newton!" program for every language and reports
 # PASS/FAIL. Designed to be run inside the built container:
 #
-#   docker run --rm -it newtonschool/judge0-newton-compiler:0.32-arm64 \
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.33-arm64 \
 #     bash /work/bin/newton-test
 #
 # Exits non-zero if any language fails, and prints a summary.
@@ -19,6 +19,8 @@
 # 0.30: restored C# coverage via Mono 6.12 plus .NET 8 and .NET 10.
 # 0.32: swapped .NET 10 for .NET Core 7 (hiring courses need net7.0
 # target compat); .NET 8 patch downshifted to 8.0.302.
+# 0.33: added DOTNET_EnableWriteXorExecute=0 to compiler ENV — fixes
+# SIGXFSZ from .NET's W^X memfd+ftruncate allocator on large-RAM hosts.
 #
 set -u
 


### PR DESCRIPTION
## Summary

.NET 6+ on Linux uses a **W^X (Write-XOR-Execute) double-mapped JIT code allocator** that calls `memfd_create` + `ftruncate` to reserve a code cache region sized from host RAM. On large-RAM hosts (EC2 prod has many GB), the reservation exceeds isolate's `RLIMIT_FSIZE` (capped at ~1-2 GiB by Judge0's `MAX_MAX_FILE_SIZE`), causing `ftruncate` to fail with `EFBIG` → `SIGXFSZ` → dotnet dies **during runtime init, before any user-visible output**.

**Diagnostic fingerprint:** `compile_output` shows `exit 153` (= 128 + 25 = SIGXFSZ) with **zero bytes** stdout/stderr from dotnet. Submissions fail with "Compilation Error" but no diagnostic to chase — exactly what we saw debugging 3007/3008 on EC2.

Verified inline yesterday: with `DOTNET_EnableWriteXorExecute=0` exported before `dotnet build`, a .NET 7 hello-world compiles cleanly in 3.75s under a 4 GiB cap. Without it, dies with SIGXFSZ at any cap value we tested (1, 2, 4 GiB).

## Changes

- `NewtonDockerFiles/NewtonDockerfile-v2`: add `DOTNET_EnableWriteXorExecute=0` to the existing Tier 12 ENV block next to `DOTNET_ROOT` / `DOTNET_NOLOGO` etc.; add 0.33 entry to the changelog comment block.
- `CLAUDE.md`: tag bump `0.32` → `0.33`; new bullet under per-language conventions documenting the W^X workaround, its rationale, and the diagnostic fingerprint so future maintainers don't burn time on this again.
- `bin/newton-test`: header tag bump + 0.33 changelog line.

## Why disabling W^X is safe here

W^X within .NET is defense-in-depth — it prevents JIT'd code from being written and executed from the same mapping, which mitigates certain runtime exploits. The **primary** security boundary for student submissions is `isolate` (separate PID namespace, mount namespace, seccomp, cgroup limits). Disabling .NET's internal W^X inside an already-sandboxed environment is acceptable. The official .NET docs explicitly support `DOTNET_EnableWriteXorExecute=0` as a workaround for environments that can't accommodate the double-mapped allocator's reservation size.

## Required follow-up

For this env var to actually reach inside the isolate sandbox, **Judge0's `IsolateJob` must propagate it via `-E`** (isolate strips env by default — only `-E` listed vars survive). Follow-up PR in `Newton-School/judge0` will:

1. Bump `NewtonDockerfile`'s `FROM` to `judge0-newton-compiler:0.33`.
2. Add `-E DOTNET_EnableWriteXorExecute` to both compile and run isolate commands in `app/jobs/isolate_job.rb`.
3. Revert the inline `DOTNET_EnableWriteXorExecute=0` from `db/languages/active.rb` 3007/3008 (the inline workaround landed in PR #31; this PR makes it durable).

## Test plan

- [ ] Build `0.33-arm64` locally and run `bin/newton-test` — expect 22 PASS / 0 FAIL / 2 SKIP on arm64. C# .NET 7 / .NET 8 lanes should still pass (env var doesn't affect them outside isolate).
- [ ] Build amd64 on EC2, smoke-test, tag/push `0.33` to Docker Hub.
- [ ] Land the Judge0 follow-up PR consuming `0.33`, restart workers, verify 3007/3008 hello-worlds return `Accepted` without any `max_file_size` override in the request body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)