### PR TITLE
[codex] Add CircuitRun dist image integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Base Docker image that ships every language toolchain Judge0 executes
 student submissions in. Built downstream as `judge0/compilers:1.4.0` (the
-upstream artifact) and `newtonschool/judge0-newton-compiler:0.33` (Newton's
+upstream artifact) and `newtonschool/judge0-newton-compiler:0.34` (Newton's
 modernised + trimmed artifact, which is what `Newton-School/judge0` actually
 consumes).
 
@@ -11,7 +11,8 @@ consumes).
 GCC 9.5 (C/C++), Java 21, Kotlin 2.3.21, Scala 3.8.3, Python 3.13 + 3.12 ML,
 Ruby 3.3.6, Node 22 + TypeScript, Go 1.23, Rust 1.83, R 4.5, Bash 5.2,
 NASM (amd64-only), FreeBASIC (amd64-only), SQLite, MARS, nand2tetris,
-Icarus Verilog 13.0, Mono 6.12 + .NET 7 + .NET 8 (C# lanes), isolate v2.
+Icarus Verilog 13.0, Mono 6.12 + .NET 7 + .NET 8 (C# lanes),
+CircuitRun Arduino Uno Arduino C++, isolate v2.
 
 Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
 
@@ -56,8 +57,12 @@ Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
   already provides the security boundary. Judge0's `IsolateJob` must
   propagate this env via `-E DOTNET_EnableWriteXorExecute` (isolate
   strips env by default).
+- **CircuitRun lives in Tier 13** as a digest-pinned dist-image artifact.
+  The compiler image mounts `/opt/circuitrun/dist` from `CIRCUITRUN_DIST_IMAGE`
+  and runs its `install.sh`; do not copy a full standalone worker image here.
+  The first production profile is Arduino Uno + Arduino C++ only.
 
-See `git log` for the 0.26 → 0.30 trim/revive chronology if you need to know
+See `git log` for the 0.26 → 0.34 trim/revive chronology if you need to know
 when a particular toolchain came or went.
 
 ## Repo layout you will care about
@@ -118,13 +123,15 @@ image (45+ min lost to this on the JDK pin in 0.26 — don't recreate it).
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.33-arm64 \
+  --build-arg CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp \
+  -t newtonschool/judge0-newton-compiler:0.34-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  -t newtonschool/judge0-newton-compiler:0.33 \
+  --build-arg CIRCUITRUN_DIST_IMAGE=<ecr-circuitrun-dist-digest> \
+  -t newtonschool/judge0-newton-compiler:0.34 \
   --load .
 ```
 
@@ -137,13 +144,13 @@ drops.
 ```bash
 docker run --rm \
   -v "$PWD/bin:/work/bin:ro" \
-  newtonschool/judge0-newton-compiler:0.33-arm64 \
+  newtonschool/judge0-newton-compiler:0.34-arm64 \
   bash /work/bin/newton-test
 ```
 
-Expected (post 0.33: 3 C# lanes — Mono legacy, .NET 7, .NET 8):
-22 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and FreeBASIC are amd64-only
-upstream and skip on arm64). 24 PASS / 0 FAIL / 0 SKIP on amd64.
+Expected after 0.34: C# lanes plus CircuitRun Arduino Uno support:
+23 PASS / 0 FAIL / 2 SKIP on arm64 (NASM and FreeBASIC are amd64-only
+upstream and skip on arm64). 25 PASS / 0 FAIL / 0 SKIP on amd64.
 
 If this isn't green, DON'T tag/push.
 
@@ -185,7 +192,7 @@ If this isn't green, DON'T tag/push.
 ## Image is published as
 
 - Docker Hub: `newtonschool/judge0-newton-compiler`
-- Current tag: **`0.33`** (amd64 produced on EC2). Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32.
+- Current tag: **`0.34`**. Earlier published: 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33.
 
 ## Production deploys
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Plain text (judge0 id 43) needs no toolchain — handled judge0-side.
   already provides the security boundary. Judge0's `IsolateJob` must
   propagate this env via `-E DOTNET_EnableWriteXorExecute` (isolate
   strips env by default).
-- **CircuitRun lives in Tier 13** as a digest-pinned dist-image artifact.
+- **CircuitRun lives in Tier 13** as a digest-pinned Docker Hub dist-image artifact.
   The compiler image mounts `/opt/circuitrun/dist` from `CIRCUITRUN_DIST_IMAGE`
   and runs its `install.sh`; do not copy a full standalone worker image here.
   The first production profile is Arduino Uno + Arduino C++ only.
@@ -130,7 +130,7 @@ docker buildx build --platform linux/arm64 \
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  --build-arg CIRCUITRUN_DIST_IMAGE=<ecr-circuitrun-dist-digest> \
+  --build-arg CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:d96a05556ce50330ea1d1bf7c235cd8fccd3282d48565bd47152035c88fd45fc \
   -t newtonschool/judge0-newton-compiler:0.34 \
   --load .
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,14 +123,12 @@ image (45+ min lost to this on the JDK pin in 0.26 — don't recreate it).
 # arm64 native (Mac dev) — ~2-2.5 hrs from scratch
 docker buildx build --platform linux/arm64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  --build-arg CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp \
   -t newtonschool/judge0-newton-compiler:0.34-arm64 \
   --load .
 
 # amd64 (EC2 / prod) — ~45-75 min on a c6i.4xlarge
 docker buildx build --platform linux/amd64 \
   -f NewtonDockerFiles/NewtonDockerfile-v2 \
-  --build-arg CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:d96a05556ce50330ea1d1bf7c235cd8fccd3282d48565bd47152035c88fd45fc \
   -t newtonschool/judge0-newton-compiler:0.34 \
   --load .
 ```

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -70,7 +70,7 @@
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:c2e2e2f5945dfc2be723b85dad50f1b1c0b8442270f5e2ad3a6c61205bb47087
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:1c7f695a367f996ff4e7de6ddae5a13f8ffb7ebeec44c2cce315b0b99f2a531c
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -70,7 +70,7 @@
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:1c7f695a367f996ff4e7de6ddae5a13f8ffb7ebeec44c2cce315b0b99f2a531c
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:f66e72923b62c885e231a4b144279e25edd2d0134c45b8ce6aa7b6e3fbb049a8
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -70,7 +70,7 @@
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:a3fa31a41b70d769009542c6b80f9cb0d0f72535771151420035555a6c898eec
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:5c4c10015d75da860d287fd1bc21249f209a962a9887c2ab9dcbb7c201edfe77
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -24,8 +24,8 @@
 #   on large hosts (EC2), killing dotnet with SIGXFSZ during runtime init.
 #   Disabling W^X uses a single RWX mapping; safe inside isolate which
 #   already provides the security boundary.
-# - 0.34: add CircuitRun Arduino Uno + Arduino C++ support from a
-#   digest-pinned dist image. The compiler image installs only the final
+# - 0.34: add CircuitRun Arduino Uno + Arduino C++ support from the
+#   digest-pinned CircuitRun dist image. The compiler image installs only the final
 #   Arduino profile payload, not the CircuitRun build toolchain or standalone
 #   worker filesystem.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
@@ -58,10 +58,18 @@
 #
 # Multi-arch: amd64 + arm64 supported via TARGETARCH branching.
 # Build:
+#   # arm64 native dev path; requires a locally built arm64 CircuitRun dist image.
 #   docker buildx build --platform linux/arm64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     --build-arg CIRCUITRUN_DIST_IMAGE=<ecr-circuitrun-dist-digest> \
+#     --build-arg CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp \
 #     -t newtonschool/judge0-newton-compiler:0.34-arm64 \
+#     compilers
+#
+#   # amd64 production path; consume the Docker Hub dist image by digest.
+#   docker buildx build --platform linux/amd64 \
+#     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
+#     --build-arg CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:d96a05556ce50330ea1d1bf7c235cd8fccd3282d48565bd47152035c88fd45fc \
+#     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
 ARG CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -70,7 +70,7 @@
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:b58d90b222daaefcd426e32ddc0b47b5112d89bff356d45911693e84a0f4972d
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:c2e2e2f5945dfc2be723b85dad50f1b1c0b8442270f5e2ad3a6c61205bb47087
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -58,21 +58,19 @@
 #
 # Multi-arch: amd64 + arm64 supported via TARGETARCH branching.
 # Build:
-#   # arm64 native dev path; requires a locally built arm64 CircuitRun dist image.
+#   # arm64 native dev path; uses the default multi-arch Docker Hub dist image digest.
 #   docker buildx build --platform linux/arm64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     --build-arg CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp \
 #     -t newtonschool/judge0-newton-compiler:0.34-arm64 \
 #     compilers
 #
-#   # amd64 production path; consume the Docker Hub dist image by digest.
+#   # amd64 production path; uses the default Docker Hub dist image digest.
 #   docker buildx build --platform linux/amd64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     --build-arg CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:d96a05556ce50330ea1d1bf7c235cd8fccd3282d48565bd47152035c88fd45fc \
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:a3fa31a41b70d769009542c6b80f9cb0d0f72535771151420035555a6c898eec
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base
@@ -156,17 +154,7 @@ ENV BOX_ROOT=/var/local/lib/isolate
 # GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
 ENV GCC_LEGACY_VERSION=9.5.0
 RUN set -xe && \
-    gcc_tarball="gcc-${GCC_LEGACY_VERSION}.tar.gz" && \
-    for mirror in \
-        "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}" \
-        "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}" \
-        "https://mirrors.kernel.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}"; do \
-        if curl -fSsL --retry 3 --retry-delay 2 --connect-timeout 20 "${mirror}/${gcc_tarball}" -o /tmp/gcc.tar.gz; then \
-            break; \
-        fi; \
-        rm -f /tmp/gcc.tar.gz; \
-    done && \
-    test -s /tmp/gcc.tar.gz && \
+    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
     mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
     rm /tmp/gcc.tar.gz && \
     cd /tmp/gcc && \
@@ -236,8 +224,7 @@ RUN set -xe && \
 # binary can resolve at runtime.
 ENV FBC_VERSION=1.10.1
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    if [ "${target_arch}" = "amd64" ]; then \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
         curl -fSsL "http://archive.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.2+20201114-2+deb11u2_amd64.deb" -o /tmp/libtinfo5.deb && \
         dpkg -i /tmp/libtinfo5.deb && \
         rm /tmp/libtinfo5.deb && \
@@ -246,7 +233,7 @@ RUN set -xe && \
         tar -xf /tmp/fbc.tar.gz -C /usr/local/fbc-${FBC_VERSION} --strip-components=1 && \
         rm /tmp/fbc.tar.gz ; \
     else \
-        echo "FreeBASIC not available for ${target_arch}; skipping" ; \
+        echo "FreeBASIC not available for ${TARGETARCH}; skipping" ; \
     fi
 
 # ════════════════════════════════════════════════════════════════════════
@@ -271,11 +258,10 @@ RUN set -xe && \
 # OpenJDK 21 LTS (Eclipse Temurin prebuilt)
 ENV JDK_VERSION=21.0.5+11
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    case "${target_arch}" in \
+    case "${TARGETARCH}" in \
         amd64) JDK_ARCH=x64 ;; \
         arm64) JDK_ARCH=aarch64 ;; \
-        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     JDK_FILE_VERSION="$(echo "${JDK_VERSION}" | tr '+' '_')" && \
     curl -fSsL "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK21U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_FILE_VERSION}.tar.gz" -o /tmp/jdk.tar.gz && \
@@ -303,11 +289,10 @@ RUN set -xe && \
 # Scala 3 (per-arch prebuilt tarball from scala/scala3 GitHub releases)
 ENV SCALA_VERSION=3.8.3
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    case "${target_arch}" in \
+    case "${TARGETARCH}" in \
         amd64) SCALA_ARCH=x86_64-pc-linux ;; \
         arm64) SCALA_ARCH=aarch64-pc-linux ;; \
-        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://github.com/scala/scala3/releases/download/${SCALA_VERSION}/scala3-${SCALA_VERSION}-${SCALA_ARCH}.tar.gz" -o /tmp/scala.tar.gz && \
     mkdir -p /usr/local/scala-${SCALA_VERSION} && \
@@ -323,11 +308,10 @@ RUN set -xe && \
 # Go (prebuilt)
 ENV GO_VERSION=1.23.4
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    case "${target_arch}" in \
+    case "${TARGETARCH}" in \
         amd64) GO_ARCH=amd64 ;; \
         arm64) GO_ARCH=arm64 ;; \
-        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz && \
     mkdir -p /usr/local/go-${GO_VERSION} && \
@@ -337,11 +321,10 @@ RUN set -xe && \
 # Rust (prebuilt static toolchain)
 ENV RUST_VERSION=1.83.0
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    case "${target_arch}" in \
+    case "${TARGETARCH}" in \
         amd64) RUST_ARCH=x86_64-unknown-linux-gnu ;; \
         arm64) RUST_ARCH=aarch64-unknown-linux-gnu ;; \
-        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://static.rust-lang.org/dist/rust-${RUST_VERSION}-${RUST_ARCH}.tar.gz" -o /tmp/rust.tar.gz && \
     mkdir /tmp/rust && tar -xf /tmp/rust.tar.gz -C /tmp/rust --strip-components=1 && \
@@ -386,11 +369,10 @@ RUN set -xe && \
 # Node.js (prebuilt tarball, interpreter only)
 ENV NODE_VERSION=22.11.0
 RUN set -xe && \
-    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
-    case "${target_arch}" in \
+    case "${TARGETARCH}" in \
         amd64) NODE_ARCH=linux-x64 ;; \
         arm64) NODE_ARCH=linux-arm64 ;; \
-        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
+        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \
     mkdir -p /usr/local/node-${NODE_VERSION} && \

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -70,7 +70,7 @@
 #     -t newtonschool/judge0-newton-compiler:0.34 \
 #     compilers
 #
-ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:5c4c10015d75da860d287fd1bc21249f209a962a9887c2ab9dcbb7c201edfe77
+ARG CIRCUITRUN_DIST_IMAGE=newtonschool/circuitrun-dist@sha256:b58d90b222daaefcd426e32ddc0b47b5112d89bff356d45911693e84a0f4972d
 FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
 
 FROM buildpack-deps:bookworm AS base

--- a/NewtonDockerFiles/NewtonDockerfile-v2
+++ b/NewtonDockerFiles/NewtonDockerfile-v2
@@ -24,6 +24,10 @@
 #   on large hosts (EC2), killing dotnet with SIGXFSZ during runtime init.
 #   Disabling W^X uses a single RWX mapping; safe inside isolate which
 #   already provides the security boundary.
+# - 0.34: add CircuitRun Arduino Uno + Arduino C++ support from a
+#   digest-pinned dist image. The compiler image installs only the final
+#   Arduino profile payload, not the CircuitRun build toolchain or standalone
+#   worker filesystem.
 # - Newton extras kept: MARS (MIPS), nand2tetris-web-ide.
 #
 # Layer ordering: stable-on-top, volatile-on-bottom.
@@ -40,6 +44,7 @@
 #   Tier 10: Python ML pip install — most volatile
 #   Tier 11: Verilog (Icarus)
 #   Tier 12: C# / .NET (restored in 0.30)
+#   Tier 13: CircuitRun Arduino Uno + Arduino C++
 #
 # Cache-friendly editing rules:
 #   - Each language's version pin is an ENV directly above its RUN block.
@@ -55,9 +60,13 @@
 # Build:
 #   docker buildx build --platform linux/arm64 \
 #     -f compilers/NewtonDockerFiles/NewtonDockerfile-v2 \
-#     -t newtonschool/judge0-newton-compiler:0.28-arm64 \
+#     --build-arg CIRCUITRUN_DIST_IMAGE=<ecr-circuitrun-dist-digest> \
+#     -t newtonschool/judge0-newton-compiler:0.34-arm64 \
 #     compilers
 #
+ARG CIRCUITRUN_DIST_IMAGE=circuitrun-dist:arduino-uno-arduino-cpp
+FROM ${CIRCUITRUN_DIST_IMAGE} AS circuitrun_dist
+
 FROM buildpack-deps:bookworm AS base
 
 ARG TARGETARCH
@@ -139,7 +148,17 @@ ENV BOX_ROOT=/var/local/lib/isolate
 # GCC 9.5.0 — frozen forever (preserves GCC-9-era student-code compatibility)
 ENV GCC_LEGACY_VERSION=9.5.0
 RUN set -xe && \
-    curl -fSsL "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}/gcc-${GCC_LEGACY_VERSION}.tar.gz" -o /tmp/gcc.tar.gz && \
+    gcc_tarball="gcc-${GCC_LEGACY_VERSION}.tar.gz" && \
+    for mirror in \
+        "https://ftpmirror.gnu.org/gcc/gcc-${GCC_LEGACY_VERSION}" \
+        "https://ftp.gnu.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}" \
+        "https://mirrors.kernel.org/gnu/gcc/gcc-${GCC_LEGACY_VERSION}"; do \
+        if curl -fSsL --retry 3 --retry-delay 2 --connect-timeout 20 "${mirror}/${gcc_tarball}" -o /tmp/gcc.tar.gz; then \
+            break; \
+        fi; \
+        rm -f /tmp/gcc.tar.gz; \
+    done && \
+    test -s /tmp/gcc.tar.gz && \
     mkdir -p /tmp/gcc && tar -xf /tmp/gcc.tar.gz -C /tmp/gcc --strip-components=1 && \
     rm /tmp/gcc.tar.gz && \
     cd /tmp/gcc && \
@@ -209,7 +228,8 @@ RUN set -xe && \
 # binary can resolve at runtime.
 ENV FBC_VERSION=1.10.1
 RUN set -xe && \
-    if [ "${TARGETARCH}" = "amd64" ]; then \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    if [ "${target_arch}" = "amd64" ]; then \
         curl -fSsL "http://archive.debian.org/debian/pool/main/n/ncurses/libtinfo5_6.2+20201114-2+deb11u2_amd64.deb" -o /tmp/libtinfo5.deb && \
         dpkg -i /tmp/libtinfo5.deb && \
         rm /tmp/libtinfo5.deb && \
@@ -218,7 +238,7 @@ RUN set -xe && \
         tar -xf /tmp/fbc.tar.gz -C /usr/local/fbc-${FBC_VERSION} --strip-components=1 && \
         rm /tmp/fbc.tar.gz ; \
     else \
-        echo "FreeBASIC not available for ${TARGETARCH}; skipping" ; \
+        echo "FreeBASIC not available for ${target_arch}; skipping" ; \
     fi
 
 # ════════════════════════════════════════════════════════════════════════
@@ -243,10 +263,11 @@ RUN set -xe && \
 # OpenJDK 21 LTS (Eclipse Temurin prebuilt)
 ENV JDK_VERSION=21.0.5+11
 RUN set -xe && \
-    case "${TARGETARCH}" in \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${target_arch}" in \
         amd64) JDK_ARCH=x64 ;; \
         arm64) JDK_ARCH=aarch64 ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
     esac && \
     JDK_FILE_VERSION="$(echo "${JDK_VERSION}" | tr '+' '_')" && \
     curl -fSsL "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${JDK_VERSION}/OpenJDK21U-jdk_${JDK_ARCH}_linux_hotspot_${JDK_FILE_VERSION}.tar.gz" -o /tmp/jdk.tar.gz && \
@@ -274,10 +295,11 @@ RUN set -xe && \
 # Scala 3 (per-arch prebuilt tarball from scala/scala3 GitHub releases)
 ENV SCALA_VERSION=3.8.3
 RUN set -xe && \
-    case "${TARGETARCH}" in \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${target_arch}" in \
         amd64) SCALA_ARCH=x86_64-pc-linux ;; \
         arm64) SCALA_ARCH=aarch64-pc-linux ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://github.com/scala/scala3/releases/download/${SCALA_VERSION}/scala3-${SCALA_VERSION}-${SCALA_ARCH}.tar.gz" -o /tmp/scala.tar.gz && \
     mkdir -p /usr/local/scala-${SCALA_VERSION} && \
@@ -293,10 +315,11 @@ RUN set -xe && \
 # Go (prebuilt)
 ENV GO_VERSION=1.23.4
 RUN set -xe && \
-    case "${TARGETARCH}" in \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${target_arch}" in \
         amd64) GO_ARCH=amd64 ;; \
         arm64) GO_ARCH=arm64 ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz && \
     mkdir -p /usr/local/go-${GO_VERSION} && \
@@ -306,10 +329,11 @@ RUN set -xe && \
 # Rust (prebuilt static toolchain)
 ENV RUST_VERSION=1.83.0
 RUN set -xe && \
-    case "${TARGETARCH}" in \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${target_arch}" in \
         amd64) RUST_ARCH=x86_64-unknown-linux-gnu ;; \
         arm64) RUST_ARCH=aarch64-unknown-linux-gnu ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://static.rust-lang.org/dist/rust-${RUST_VERSION}-${RUST_ARCH}.tar.gz" -o /tmp/rust.tar.gz && \
     mkdir /tmp/rust && tar -xf /tmp/rust.tar.gz -C /tmp/rust --strip-components=1 && \
@@ -354,10 +378,11 @@ RUN set -xe && \
 # Node.js (prebuilt tarball, interpreter only)
 ENV NODE_VERSION=22.11.0
 RUN set -xe && \
-    case "${TARGETARCH}" in \
+    target_arch="${TARGETARCH:-$(dpkg --print-architecture)}" && \
+    case "${target_arch}" in \
         amd64) NODE_ARCH=linux-x64 ;; \
         arm64) NODE_ARCH=linux-arm64 ;; \
-        *) echo "unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+        *) echo "unsupported arch: ${target_arch}" && exit 1 ;; \
     esac && \
     curl -fSsL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-${NODE_ARCH}.tar.xz" -o /tmp/node.tar.xz && \
     mkdir -p /usr/local/node-${NODE_VERSION} && \
@@ -530,6 +555,42 @@ ENV DOTNET_ROOT=/usr/local/dotnet-sdk \
     DOTNET_EnableWriteXorExecute=0
 
 # ════════════════════════════════════════════════════════════════════════
+# Tier 13 — CircuitRun embedded-systems runtime
+#
+# CircuitRun is built and smoke-tested in its own dist image, then mounted
+# into this compilers build as an immutable artifact. The mounted dist is not
+# persisted as a temporary layer; only install.sh's final /usr/local payload is
+# kept in the compiler image. The first production profile intentionally ships
+# only Arduino Uno + Arduino C++.
+# ════════════════════════════════════════════════════════════════════════
+
+RUN --mount=from=circuitrun_dist,source=/opt/circuitrun/dist,target=/tmp/circuitrun-dist,readonly \
+    set -xe && \
+    /tmp/circuitrun-dist/install.sh && \
+    arduino-cli version >/dev/null && \
+    circuitrun --help >/dev/null && \
+    circuitrun-judge0-runner --help >/dev/null && \
+    test -x /usr/local/bin/circuitrun-compile-arduino && \
+    test -x /usr/local/bin/circuitrun-backend-simavr && \
+    test -x /usr/local/bin/circuitrun-simavr-driver && \
+    test -f /usr/local/share/circuitrun/profile.json && \
+    test -f /usr/local/share/circuitrun/arduino15/library_index.json && \
+    test -f /usr/local/share/circuitrun/arduino15/package_index.json && \
+    test -d /usr/local/share/circuitrun/arduino15/packages/builtin/tools/ctags && \
+    test -d /usr/local/share/circuitrun/arduino15/packages/arduino/hardware/avr && \
+    test -d /usr/local/share/circuitrun/arduino15/packages/arduino/tools/avr-gcc && \
+    test ! -e /usr/local/bin/circuitrun-compile-pico-sdk && \
+    test ! -e /usr/local/bin/circuitrun-compile-esp-idf && \
+    test ! -e /usr/local/bin/circuitrun-rp2040js-driver && \
+    test ! -e /usr/local/bin/circuitrun-qemu-esp32-driver && \
+    test ! -e /usr/local/bin/circuitrun-idf.py && \
+    test ! -e /usr/local/bin/circuitrun-esptool.py && \
+    test ! -e /usr/local/bin/picotool && \
+    test ! -e /usr/local/share/circuitrun/pico-sdk && \
+    test ! -e /usr/local/share/circuitrun/esp-idf && \
+    test ! -e /usr/local/share/circuitrun/espressif
+
+# ════════════════════════════════════════════════════════════════════════
 # Final wiring
 # ════════════════════════════════════════════════════════════════════════
 
@@ -538,4 +599,4 @@ ENV PATH="/usr/local/dotnet-sdk:/usr/local/openjdk-21/bin:/usr/local/bin:/usr/lo
 LABEL maintainer="Gaurav Kapatia <gkapatia@newtonschool.co>" \
       org.opencontainers.image.source="https://github.com/Newton-School/compilers" \
       org.opencontainers.image.description="Newton School Judge0 compilers image (v2, modernised, trimmed)" \
-      org.opencontainers.image.version="0.30"
+      org.opencontainers.image.version="0.34"

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -390,7 +390,7 @@ EOF
   }
 }
 EOF
-        circuitrun-judge0-runner judge0-evaluate --board arduino-uno --language arduino-cpp --source src/main.ino --asset-dir artifacts < request.json
+        circuitrun-judge0-runner judge0-run --board arduino-uno --language arduino-cpp --source src/main.ino --asset-dir artifacts < request.json
     " "CIRCUITRUN_EVALUATE_ACCEPTED"
 else skip "CircuitRun Arduino Uno Arduino C++" "circuitrun-judge0-runner not installed"; fi
 

--- a/bin/newton-test
+++ b/bin/newton-test
@@ -5,7 +5,7 @@
 # Runs a tiny "Hello, Newton!" program for every language and reports
 # PASS/FAIL. Designed to be run inside the built container:
 #
-#   docker run --rm -it newtonschool/judge0-newton-compiler:0.33-arm64 \
+#   docker run --rm -it newtonschool/judge0-newton-compiler:0.34-arm64 \
 #     bash /work/bin/newton-test
 #
 # Exits non-zero if any language fails, and prints a summary.
@@ -21,6 +21,7 @@
 # target compat); .NET 8 patch downshifted to 8.0.302.
 # 0.33: added DOTNET_EnableWriteXorExecute=0 to compiler ENV — fixes
 # SIGXFSZ from .NET's W^X memfd+ftruncate allocator on large-RAM hosts.
+# 0.34: added CircuitRun Arduino Uno + Arduino C++ compiler-image smoke.
 #
 set -u
 
@@ -343,6 +344,55 @@ endmodule
 EOF
         $IVERILOG_DIR/bin/iverilog -g2012 -o sim.vvp main.v && $IVERILOG_DIR/bin/vvp sim.vvp"
 else skip "Verilog (Icarus)" "no /usr/local/iverilog-*"; fi
+
+# ────────────────────────────────────────────────────────────────────────
+section "Embedded systems"
+# ────────────────────────────────────────────────────────────────────────
+if command -v circuitrun-judge0-runner >/dev/null; then
+    t "CircuitRun Arduino Uno Arduino C++" circuitrun "
+        mkdir -p src
+        cat > src/main.ino <<'EOF'
+void setup() {
+  pinMode(13, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(13, HIGH);
+  delay(100);
+  digitalWrite(13, LOW);
+  delay(100);
+}
+EOF
+        cat > request.json <<'EOF'
+{
+  \"schema_version\": \"2026-05-01\",
+  \"scenario\": {
+    \"duration_ms\": 1000,
+    \"stimuli\": []
+  },
+  \"checks\": [
+    {
+      \"type\": \"pin-toggled\",
+      \"id\": \"led-blinks\",
+      \"pin\": \"D13\",
+      \"min_count\": 2
+    }
+  ],
+  \"artifacts\": {
+    \"enabled\": [\"result.json\", \"trace.ndjson\", \"waveform.json\", \"serial.log\"]
+  },
+  \"limits\": {
+    \"max_wall_ms\": 20000
+  },
+  \"context\": {
+    \"question_id\": \"compiler-image-smoke\",
+    \"test_case_id\": \"arduino-uno-arduino-cpp\"
+  }
+}
+EOF
+        circuitrun-judge0-runner judge0-evaluate --board arduino-uno --language arduino-cpp --source src/main.ino --asset-dir artifacts < request.json
+    " "CIRCUITRUN_EVALUATE_ACCEPTED"
+else skip "CircuitRun Arduino Uno Arduino C++" "circuitrun-judge0-runner not installed"; fi
 
 # ────────────────────────────────────────────────────────────────────────
 section "Sandbox"


### PR DESCRIPTION
## Summary
- mount the CircuitRun Arduino Uno Arduino C++ dist image into NewtonDockerfile-v2 through CIRCUITRUN_DIST_IMAGE
- install and validate only the profile-scoped CircuitRun runtime payload in the compiler image
- add a CircuitRun Arduino Uno smoke lane to bin/newton-test and update CLAUDE.md for the 0.34 image state

## Validation
- git diff --check --cached
- bash -n bin/newton-test

## Notes
- CircuitRun is appended as Tier 13; the upstream C#/.NET Tier 12 changes from origin/master are preserved.
- The untracked local bin/circuitrun-judge0-runner file was intentionally not included; the runner comes from the CircuitRun dist image.